### PR TITLE
Improve/simplify C++ book recommandations

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ title: Home
     <li>Read the <a href="https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md">Contributing to Bitcoin Core Guide</a>. This will help you understand the process and some of the terminology we use in Bitcoin Core.</li>
     <li>Look at the <a href="https://github.com/bitcoin/bitcoin/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">good first issues</a> and  <a href="https://github.com/bitcoin/bitcoin/issues?utf8=%E2%9C%93&q=label%3A%22Up+for+grabs%22">up for grabs</a> list.</li>
     <li>Read the <a href="https://github.com/bitcoin/bitcoin/blob/master/doc/productivity.md">Bitcoin Core developer productivity tips</a>.</li>
-    <li>Brush up on your C++. There are many primers and reference manuals available. Some contributors recommend <a href="https://www.amazon.com/Primer-Plus-6th-Developers-Library/dp/0321776402">C++ Primer Plus</a> or <a href="https://www.amazon.com/Thinking-Vol-Introduction-Standard-2nd/dp/0139798099/ref=sr_1_1?keywords=thinking+in+C%2B%2B&qid=1555344308&s=books&sr=1-1">Thinking in C++</a> which may be a little dated and doesn't cover C++11 or 14.</li>
+    <li>Brush up on your C++. There are <a href="https://stackoverflow.com/questions/388242/the-definitive-c-book-guide-and-list">many primers and reference manuals available</a>.</li>
     <li>Blog posts on contributing to Bitcoin Core from <a href="https://bitcointechtalk.com/a-gentle-introduction-to-bitcoin-core-development-fdc95eaee6b8">Jimmy Song</a> and <a href="https://bitcointechtalk.com/contributing-to-bitcoin-core-a-personal-account-35f3a594340b">John Newbery</a>.</li>
   </ul>
 </div>


### PR DESCRIPTION
Remove "C++ Primer Plus". Here are 3 links that explain why:

  - https://www.reddit.com/r/cpp/comments/13g6s1/which_c_primer_book_is_better/
  - https://www.quora.com/Between-C++-Primer-Plus-and-C++-Primer-which-is-better-and-why
  - http://www.cplusplus.com/forum/beginner/106097/

[C++ Primer, 5th Edition](https://www.amazon.com/Primer-5th-Stanley-B-Lippman/dp/0321714113/) and the dated but compact and well-regarded [Accelerated C++](https://www.amazon.com/Accelerated-C-Practical-Programming-Example/dp/020170353X/) are introductory books I've worked through and can recommend. That said, individual readers' needs vary, and it may be best to simply provide a link to this (quite good) list of books organised by category:

  - https://stackoverflow.com/questions/388242/the-definitive-c-book-guide-and-list
