### PR TITLE
Doc: Fix command to launch Jekyll server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You'll need [Ruby & Jekyll](https://jekyllrb.com/docs/installation/) to run the 
 
 * Clone the repository and go into the directory
 * Run `bundle install`
-* Run `jekyll serve`
+* Run `bundle exec jekyll serve`
 * Go to http://localhost:4000
 
 ## Making a Post


### PR DESCRIPTION
per usual practice and https://jekyllrb.com/docs

Omitting `bundle exec` can cause errors like:

```
You have already activated liquid 4.0.3, but your Gemfile requires liquid 4.0.0.
Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
```

Cheers.