### PR TITLE
doc: update README intro and add website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bitcoin-core-review-club
 
-Simple Jekyll site for hosting information about upcoming Bitcoin Core PR Review club information.
+Simple Jekyll site for hosting the Bitcoin Core PR Review club at https://bitcoin-core-review-club.github.io/.
 
 ## Development
 


### PR DESCRIPTION
Trivial update to the README to:

1. update/simplify the introductory description because the website is no longer only about upcoming meetings; it now contains a history and log of past meetings, and

2. add the website URL to enable easily navigating from the repository to the website (something I've been missing, so this is the real reason).

Click here here to test this change:

https://github.com/jonatack/bitcoin-core-review-club.github.io/tree/add-website-url-to-readme-doc

Cheers!