### PR TITLE
Add pr page template and page variables

### DIFF
--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+
+<section>
+  <div class="post-content">
+    <h1>{{ page.title }} ({{ page.component }})</h1>
+      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">
+        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+        {{ page.date | date: date_format }}
+      </time>
+    <p style="font-weight:bold"><a href="https://github.com/bitcoin/bitcoin/pull/{{ page.pr }}">https://github.com/bitcoin/bitcoin/{{ page.pr }}</a></p>
+    <p class="host">Host: <a href="https://github.com/{{ page.host }}">{{ page.host }}</a></p>
+    <p>{{ content }}</p>
+  </div>
+</section>

--- a/_posts/2019-05-01-#15557.md
+++ b/_posts/2019-05-01-#15557.md
@@ -1,9 +1,10 @@
 ---
-layout: post
-title: "#15557 Enhance bumpfee to include inputs when targeting a feerate (wallet)"
+layout: pr
+title: "#15557 Enhance bumpfee to include inputs when targeting a feerate"
+component: wallet
+pr: 15557
+host: jnewbery
 ---
-
-__[https://github.com/bitcoin/bitcoin/pull/15557](https://github.com/bitcoin/bitcoin/pull/15557)__
 
 ## Meeting log
 

--- a/_posts/2019-05-08-#10823.md
+++ b/_posts/2019-05-08-#10823.md
@@ -1,9 +1,10 @@
 ---
-layout: post
-title: "#10823 Allow all mempool txs to be replaced after a configurable timeout (default 6h) (mempool/policy)"
+layout: pr
+title: "#10823 Allow all mempool txs to be replaced after a configurable timeout (default 6h)"
+component: mempool
+pr: 10823
+host: jnewbery
 ---
-
-__[https://github.com/bitcoin/bitcoin/pull/10823](https://github.com/bitcoin/bitcoin/pull/10823)__
 
 ## Meeting log
 

--- a/_posts/2019-05-15-#15834.md
+++ b/_posts/2019-05-15-#15834.md
@@ -1,9 +1,10 @@
 ---
-layout: post
-title: "#15834 Fix NOTFOUND bug and expire getdata requests for transactions (net processing)"
+layout: pr
+title: "#15834 Fix NOTFOUND bug and expire getdata requests for transactions"
+component: net processing
+pr: 15834
+host: jnewbery
 ---
-
-__[https://github.com/bitcoin/bitcoin/pull/15834](https://github.com/bitcoin/bitcoin/pull/15834)__
 
 ## Meeting log
 

--- a/_posts/2019-05-22-#15450.md
+++ b/_posts/2019-05-22-#15450.md
@@ -1,6 +1,6 @@
 ---
 layout: pr
-title: "#15450 [GUI] Create wallet menu option"
+title: "#15450 Create wallet menu option"
 component: gui
 pr: 15450
 host: jnewbery

--- a/_posts/2019-05-22-#15450.md
+++ b/_posts/2019-05-22-#15450.md
@@ -1,9 +1,10 @@
 ---
-layout: post
-title: "#15450 [GUI] Create wallet menu option (GUI)"
+layout: pr
+title: "#15450 [GUI] Create wallet menu option"
+component: gui
+pr: 15450
+host: jnewbery
 ---
-
-__[https://github.com/bitcoin/bitcoin/pull/15450](https://github.com/bitcoin/bitcoin/pull/15450)__
 
 ## Notes
 

--- a/_posts/2019-05-29-#15741.md
+++ b/_posts/2019-05-29-#15741.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#15741 Batch write imported stuff in importmulti (wallet)"
+layout: pr
+title: "#15741 Batch write imported stuff in importmulti"
+component: wallet
+pr: 15741
+host: ariard
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/15741](https://github.com/bitcoin/bitcoin/pull/15741)

--- a/_posts/2019-06-05-#16060.md
+++ b/_posts/2019-06-05-#16060.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#16060 Bury bip9 deployments (consensus)"
+layout: pr
+title: "#16060 Bury bip9 deployments"
+component: consensus
+pr: 16060
+host: jnewbery
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/16060](https://github.com/bitcoin/bitcoin/pull/16060)

--- a/_posts/2019-06-12-#15996.md
+++ b/_posts/2019-06-12-#15996.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#15996 Deprecate totalfee argument in `bumpfee` (RPC)"
+layout: pr
+title: "#15996 Deprecate totalfee argument in `bumpfee`"
+component: rpc
+pr: 15996
+host: jnewbery
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/15996](https://github.com/bitcoin/bitcoin/pull/15996)

--- a/_posts/2019-06-19-#15481.md
+++ b/_posts/2019-06-19-#15481.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#15481 Restrict timestamp when mining a diff-adjustment block to prev-600 (mining)"
+layout: pr
+title: "#15481 Restrict timestamp when mining a diff-adjustment block to prev-600"
+component: mining
+pr: 15481
+host: jnewbery
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/15481](https://github.com/bitcoin/bitcoin/pull/15481)

--- a/_posts/2019-06-26-#15681.md
+++ b/_posts/2019-06-26-#15681.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#15681 Allow one extra single-ancestor transaction per package (mempool)"
+layout: pr
+title: "#15681 Allow one extra single-ancestor transaction per package"
+component: mempool
+pr: 15681
+host: harding
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/15681](https://github.com/bitcoin/bitcoin/pull/15681)

--- a/_posts/2019-07-03-#15443.md
+++ b/_posts/2019-07-03-#15443.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#15443 Add getdescriptorinfo functional test (tests)"
+layout: pr
+title: "#15443 Add getdescriptorinfo functional test"
+component: tests
+pr: 15443
+host: jnewbery
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/15443](https://github.com/bitcoin/bitcoin/pull/15443)

--- a/_posts/2019-07-10-#16244.md
+++ b/_posts/2019-07-10-#16244.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#16244 Move wallet creation out of the createwallet rpc into its own function (wallet)"
+layout: pr
+title: "#16244 Move wallet creation out of the createwallet rpc into its own function"
+component: wallet
+pr: 16244
+host: jnewbery
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/16244](https://github.com/bitcoin/bitcoin/pull/16244)

--- a/_posts/2019-07-17-#15169.md
+++ b/_posts/2019-07-17-#15169.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#15169 Parallelize CheckInputs() in AcceptToMemoryPool() (mempool)"
+layout: pr
+title: "#15169 Parallelize CheckInputs() in AcceptToMemoryPool()"
+component: mempool
+pr: 15169
+host: jachiang
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/15169](https://github.com/bitcoin/bitcoin/pull/15169)

--- a/_posts/2019-07-24-#15713.md
+++ b/_posts/2019-07-24-#15713.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#15713 refactor: Replace chain relayTransactions/submitMemoryPool by higher method (wallet)"
+layout: pr
+title: "#15713 refactor: Replace chain relayTransactions/submitMemoryPool by higher method"
+component: wallet
+pr: 15713
+host: jnewbery
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/15713](https://github.com/bitcoin/bitcoin/pull/15713)

--- a/_posts/2019-07-31-#15505.md
+++ b/_posts/2019-07-31-#15505.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#15505 [p2p] Request NOTFOUND transactions immediately from other outbound peers, when possible (p2p)"
+layout: pr
+title: "#15505 [p2p] Request NOTFOUND transactions immediately from other outbound peers, when possible"
+component: p2p
+pr: 15505
+host: mzumsande
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/15505](https://github.com/bitcoin/bitcoin/pull/15505)

--- a/_posts/2019-07-31-#15505.md
+++ b/_posts/2019-07-31-#15505.md
@@ -1,6 +1,6 @@
 ---
 layout: pr
-title: "#15505 [p2p] Request NOTFOUND transactions immediately from other outbound peers, when possible"
+title: "#15505 Request NOTFOUND transactions immediately from other outbound peers, when possible"
 component: p2p
 pr: 15505
 host: mzumsande

--- a/_posts/2019-08-07-#16345.md
+++ b/_posts/2019-08-07-#16345.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#16345 Add getblockbyheight method / #16439 support @height in place of blockhash for getblock etc (rpc)"
+layout: pr
+title: "#16345 Add getblockbyheight method / #16439 support @height in place of blockhash for getblock etc"
+component: rpc
+pr: 16345
+host: jnewbery
 ---
 
 - [https://github.com/bitcoin/bitcoin/pull/16345](https://github.com/bitcoin/bitcoin/pull/16345)

--- a/_posts/2019-08-14-#16115.md
+++ b/_posts/2019-08-14-#16115.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#16115 On bitcoind startup, write config args to debug.log (config)"
+layout: pr
+title: "#16115 On bitcoind startup, write config args to debug.log"
+component: config
+pr: 16115
+host: jnewbery
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/16115](https://github.com/bitcoin/bitcoin/pull/16115)

--- a/_posts/2019-08-21-#15931.md
+++ b/_posts/2019-08-21-#15931.md
@@ -1,9 +1,10 @@
 ---
-layout: post
-title: "#15931 Remove GetDepthInMainChain dependency on locked chain interface (wallet)"
+layout: pr
+title: "#15931 Remove GetDepthInMainChain dependency on locked chain interface"
+component: wallet
+pr: 15931
+host: jnewbery
 ---
-
-[https://github.com/bitcoin/bitcoin/pull/15931](https://github.com/bitcoin/bitcoin/pull/15931)
 
 ## Notes
 

--- a/_posts/2019-08-28-#15759.md
+++ b/_posts/2019-08-28-#15759.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#15759 Add 2 outbound blocks-only connections (p2p)"
+layout: pr
+title: "#15759 Add 2 outbound blocks-only connections"
+component: p2p
+pr: 15759
+host: jnewbery
 ---
 
 [https://github.com/bitcoin/bitcoin/pull/15759](https://github.com/bitcoin/bitcoin/pull/15759)

--- a/_posts/2019-09-04-#16512.md
+++ b/_posts/2019-09-04-#16512.md
@@ -1,6 +1,9 @@
 ---
-layout: post
-title: "#16512 Shuffle inputs and outputs after joining psbts (RPC)"
+layout: pr
+title: "#16512 Shuffle inputs and outputs after joining psbts"
+component: rpc
+pr: 16512
+host: jnewbery
 ---
 
 Today's PR is very small and should be a quick review. We'll spend half the
@@ -8,8 +11,6 @@ time talking about the PR and half covering general questions about the Bitcoin
 Core review process.
 
 Please come prepared with your own questions about review in Bitcoin Core!
-
-[https://github.com/bitcoin/bitcoin/pull/16512](https://github.com/bitcoin/bitcoin/pull/16512)
 
 ## Notes
 

--- a/_posts/2019-09-11-#16688.md
+++ b/_posts/2019-09-11-#16688.md
@@ -1,9 +1,10 @@
 ---
-layout: post
-title: "#16688 log: Add validation interface logging (logging)"
+layout: pr
+title: "#16688 log: Add validation interface logging"
+component: logging
+pr: 15204
+host: jkczyz
 ---
-
-[https://github.com/bitcoin/bitcoin/pull/16688](https://github.com/bitcoin/bitcoin/pull/16688)
 
 ## Notes
 

--- a/_posts/2019-09-18-#15204.md
+++ b/_posts/2019-09-18-#15204.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15204 Add Open External Wallet action"
-component: GUI
+component: gui
 pr: 15204
 host: jnewbery
 ---

--- a/_posts/2019-09-18-#15204.md
+++ b/_posts/2019-09-18-#15204.md
@@ -1,9 +1,10 @@
 ---
-layout: post
-title: "#15204 Add Open External Wallet action (GUI)"
+layout: pr
+title: "#15204 Add Open External Wallet action"
+component: GUI
+pr: 15204
+host: jnewbery
 ---
-
-[https://github.com/bitcoin/bitcoin/pull/15204](https://github.com/bitcoin/bitcoin/pull/15204)
 
 ## Notes
 

--- a/_posts/2019-09-25-#16202.md
+++ b/_posts/2019-09-25-#16202.md
@@ -1,9 +1,10 @@
 ---
-layout: post
-title: "#16202 Refactor network message deserialization (net processing)"
+layout: pr
+title: "#16202 Refactor network message deserialization"
+component: net processing
+pr: 16202
+host: jonatack
 ---
-
-[https://github.com/bitcoin/bitcoin/pull/16202](https://github.com/bitcoin/bitcoin/pull/16202)
 
 ## Notes
 

--- a/_posts/2019-10-02-#16401.md
+++ b/_posts/2019-10-02-#16401.md
@@ -1,9 +1,10 @@
 ---
-layout: post
-title: "#16401 Package relay (p2p)"
+layout: pr
+title: "#16401 Package relay"
+component: p2p
+pr: 16401
+host: jonatack
 ---
-
-[https://github.com/bitcoin/bitcoin/pull/16401](https://github.com/bitcoin/bitcoin/pull/16401)
 
 ## Notes
 

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -47,3 +47,7 @@ a
 .dt-published
   color: #828282
   font-size: 0.95em
+
+.host
+  color: #828282
+  font-size: 0.95em

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ title: Home
         <div class="Home-posts-post">
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }} ({{post.component}})</a>
         </div>
     {%- endif -%}
     {% endfor %}
@@ -42,7 +42,7 @@ title: Home
         <div class="Home-posts-post">
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }} ({{post.component}})</a>
         </div>
     {%- endif -%}
     {% endfor %}

--- a/previous_meetings.html
+++ b/previous_meetings.html
@@ -11,7 +11,7 @@ title: Previous Meetings
         <div class="Home-posts-post">
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+	  <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }} ({{ post.component }})</a>
         </div>
     {%- endif -%}
     {% endfor %}

--- a/previous_meetings.html
+++ b/previous_meetings.html
@@ -11,7 +11,7 @@ title: Previous Meetings
         <div class="Home-posts-post">
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
-	  <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }} ({{ post.component }})</a>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }} ({{ post.component }})</a>
         </div>
     {%- endif -%}
     {% endfor %}


### PR DESCRIPTION
I've only implemented this for the next meeting, but the idea is:

- reduce boilerplate content in pages
- tag meetings by component and host so we can add indexes for those later (eg https://bitcoin-core-review-club.github.io/component/wallet would list all of the wallet PRs that we've discussed)