### PR TITLE
Add components and hosts indexes

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -7,7 +7,7 @@ author:
 menu:
 # Uncomment to activate the menu looping function in the header.html file under _includes
 - {name: 'Home', url: ''}
-- {name: 'Previous meetings', url: 'previous_meetings.html'}
+- {name: 'Meetings', url: 'meetings.html'}
 
 social:
 # Uncomment to activate the social media icon looping function in the footer.html file under _includes

--- a/_includes/linkers/meetings-pages.md
+++ b/_includes/linkers/meetings-pages.md
@@ -1,16 +1,17 @@
 {% capture /dev/null %}
-{% if page.url == "/meetings/" %}
-  {% assign _index_links = _index_links | append: "<span style='font-weight: bold'>By date</span>" %}
+{% assign path = page.path | remove: ".html" %}
+{% if path == "meetings" %}
+  {% assign _index_links = _index_links | append: "<strong>By date</strong>" %}
 {% else %}
   {% assign _index_links = _index_links | append: "<a href='/meetings/'>By date</a>" %}
 {% endif %}
-{% if page.url == "/en/meetings-components/" %}
-  {% assign _index_links = _index_links | append: " | <span style='font-weight: bold'>Components</span>" %}
+{% if path == "meetings-components" %}
+  {% assign _index_links = _index_links | append: " | <strong>Components</strong>" %}
 {% else %}
   {% assign _index_links = _index_links | append: " | <a href='/meetings-components/'>Components</a>" %}
 {% endif %}
-{% if page.url == "/en/meetings-hosts/" %}
-  {% assign _index_links = _index_links | append: " | <span style='font-weight: bold'>Hosts</span>" %}
+{% if path == "meetings-hosts" %}
+  {% assign _index_links = _index_links | append: " | <strong>Hosts</strong>" %}
 {% else %}
   {% assign _index_links = _index_links | append: " | <a href='/meetings-hosts/'>Hosts</a>" %}
 {% endif %}

--- a/_includes/linkers/meetings-pages.md
+++ b/_includes/linkers/meetings-pages.md
@@ -1,19 +1,19 @@
 {% capture /dev/null %}
 {% assign path = page.path | remove: ".html" %}
 {% if path == "meetings" %}
-  {% assign _index_links = _index_links | append: "<strong>By date</strong>" %}
+  {% assign _index_links = _index_links | append: "<strong>by date</strong>" %}
 {% else %}
-  {% assign _index_links = _index_links | append: "<a href='/meetings/'>By date</a>" %}
+  {% assign _index_links = _index_links | append: "<a href='/meetings/'>by date</a>" %}
 {% endif %}
 {% if path == "meetings-components" %}
-  {% assign _index_links = _index_links | append: " | <strong>Components</strong>" %}
+  {% assign _index_links = _index_links | append: " | <strong>by component</strong>" %}
 {% else %}
-  {% assign _index_links = _index_links | append: " | <a href='/meetings-components/'>Components</a>" %}
+  {% assign _index_links = _index_links | append: " | <a href='/meetings-components/'>by component</a>" %}
 {% endif %}
 {% if path == "meetings-hosts" %}
-  {% assign _index_links = _index_links | append: " | <strong>Hosts</strong>" %}
+  {% assign _index_links = _index_links | append: " | <strong>by host</strong>" %}
 {% else %}
-  {% assign _index_links = _index_links | append: " | <a href='/meetings-hosts/'>Hosts</a>" %}
+  {% assign _index_links = _index_links | append: " | <a href='/meetings-hosts/'>by host</a>" %}
 {% endif %}
 {% endcapture %}
 | {{_index_links}} |

--- a/_includes/linkers/meetings-pages.md
+++ b/_includes/linkers/meetings-pages.md
@@ -1,0 +1,18 @@
+{% capture /dev/null %}
+{% if page.url == "/meetings/" %}
+  {% assign _index_links = _index_links | append: "<span style='font-weight: bold'>By date</span>" %}
+{% else %}
+  {% assign _index_links = _index_links | append: "<a href='/meetings/'>By date</a>" %}
+{% endif %}
+{% if page.url == "/en/meetings-components/" %}
+  {% assign _index_links = _index_links | append: " | <span style='font-weight: bold'>Components</span>" %}
+{% else %}
+  {% assign _index_links = _index_links | append: " | <a href='/meetings-components/'>Components</a>" %}
+{% endif %}
+{% if page.url == "/en/meetings-hosts/" %}
+  {% assign _index_links = _index_links | append: " | <span style='font-weight: bold'>Hosts</span>" %}
+{% else %}
+  {% assign _index_links = _index_links | append: " | <a href='/meetings-hosts/'>Hosts</a>" %}
+{% endif %}
+{% endcapture %}
+| {{_index_links}} |

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -11,12 +11,24 @@ layout: default
 <section>
   <div class="post-content">
     <h1>{{ page.title }} ({{components}})</h1>
-      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">
-        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-        {{ page.date | date: date_format }}
-      </time>
-    <p style="font-weight:bold"><a href="https://github.com/bitcoin/bitcoin/pull/{{ page.pr }}">https://github.com/bitcoin/bitcoin/{{ page.pr }}</a></p>
-    <p class="host">Host: <a class="host" href="/meetings-hosts/#{{ page.host }}">{{ page.host }}</a> <a href="https://github.com/{{ page.host }}"><i class="fa fa-github"></i></a></p>
-    <p>{{ content }}</p>
+    <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">
+      {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+      {{ page.date | date: date_format }}
+    </time>
+    <p style="font-weight:bold">
+      <a href="https://github.com/bitcoin/bitcoin/pull/{{ page.pr }}">
+        https://github.com/bitcoin/bitcoin/{{ page.pr }}
+      </a>
+    </p>
+    <p class="host">
+      Host:
+      <a class="host" href="/meetings-hosts/#{{ page.host }}">{{ page.host }}</a>
+      <a href="https://github.com/{{ page.host }}">
+        <i class="fa fa-github"></i>
+      </a>
+    </p>
+    <p>
+      {{ content }}
+    </p>
   </div>
 </section>

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -10,7 +10,7 @@ layout: default
         {{ page.date | date: date_format }}
       </time>
     <p style="font-weight:bold"><a href="https://github.com/bitcoin/bitcoin/pull/{{ page.pr }}">https://github.com/bitcoin/bitcoin/{{ page.pr }}</a></p>
-    <p class="host">Host: <a href="https://github.com/{{ page.host }}">{{ page.host }}</a></p>
+    <p class="host">Host: <a class="host" href="/meetings-hosts/#{{ page.host }}">{{ page.host }}</a> <a href="https://github.com/{{ page.host }}"><i class="fa fa-github"></i></a></p>
     <p>{{ content }}</p>
   </div>
 </section>

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -2,9 +2,15 @@
 layout: default
 ---
 
+{% capture components %}
+  {%- for comp in page.components -%}
+    <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+  {%- endfor -%}
+{% endcapture %}
+
 <section>
   <div class="post-content">
-    <h1>{{ page.title }} ({{ page.component }})</h1>
+    <h1>{{ page.title }} ({{components}})</h1>
       <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">
         {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
         {{ page.date | date: date_format }}

--- a/_posts/2019-05-01-#15557.md
+++ b/_posts/2019-05-01-#15557.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15557 Enhance bumpfee to include inputs when targeting a feerate"
-component: wallet
+components: [wallet]
 pr: 15557
 host: jnewbery
 ---

--- a/_posts/2019-05-08-#10823.md
+++ b/_posts/2019-05-08-#10823.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#10823 Allow all mempool txs to be replaced after a configurable timeout (default 6h)"
-component: mempool
+components: [mempool, policy]
 pr: 10823
 host: jnewbery
 ---

--- a/_posts/2019-05-15-#15834.md
+++ b/_posts/2019-05-15-#15834.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15834 Fix NOTFOUND bug and expire getdata requests for transactions"
-component: net processing
+components: [net processing]
 pr: 15834
 host: jnewbery
 ---

--- a/_posts/2019-05-22-#15450.md
+++ b/_posts/2019-05-22-#15450.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15450 Create wallet menu option"
-component: gui
+components: [gui]
 pr: 15450
 host: jnewbery
 ---

--- a/_posts/2019-05-29-#15741.md
+++ b/_posts/2019-05-29-#15741.md
@@ -6,8 +6,6 @@ pr: 15741
 host: ariard
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/15741](https://github.com/bitcoin/bitcoin/pull/15741)
-
 ## Meeting log
 
 ```

--- a/_posts/2019-05-29-#15741.md
+++ b/_posts/2019-05-29-#15741.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15741 Batch write imported stuff in importmulti"
-component: wallet
+components: [wallet]
 pr: 15741
 host: ariard
 ---

--- a/_posts/2019-06-05-#16060.md
+++ b/_posts/2019-06-05-#16060.md
@@ -6,8 +6,6 @@ pr: 16060
 host: jnewbery
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/16060](https://github.com/bitcoin/bitcoin/pull/16060)
-
 ## Notes
 
 - Softforks have used a variety of deployment methods in the past:

--- a/_posts/2019-06-05-#16060.md
+++ b/_posts/2019-06-05-#16060.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#16060 Bury bip9 deployments"
-component: consensus
+components: [consensus]
 pr: 16060
 host: jnewbery
 ---

--- a/_posts/2019-06-12-#15996.md
+++ b/_posts/2019-06-12-#15996.md
@@ -6,8 +6,6 @@ pr: 15996
 host: jnewbery
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/15996](https://github.com/bitcoin/bitcoin/pull/15996)
-
 ## Meeting Log
 
 ```

--- a/_posts/2019-06-12-#15996.md
+++ b/_posts/2019-06-12-#15996.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15996 Deprecate totalfee argument in `bumpfee`"
-component: rpc
+components: [rpc]
 pr: 15996
 host: jnewbery
 ---

--- a/_posts/2019-06-19-#15481.md
+++ b/_posts/2019-06-19-#15481.md
@@ -6,8 +6,6 @@ pr: 15481
 host: jnewbery
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/15481](https://github.com/bitcoin/bitcoin/pull/15481)
-
 ## Notes
 
 - This PR was proposed in preparation for Matt Corallo's _Great Consensus

--- a/_posts/2019-06-19-#15481.md
+++ b/_posts/2019-06-19-#15481.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15481 Restrict timestamp when mining a diff-adjustment block to prev-600"
-component: mining
+components: [mining]
 pr: 15481
 host: jnewbery
 ---

--- a/_posts/2019-06-26-#15681.md
+++ b/_posts/2019-06-26-#15681.md
@@ -6,8 +6,6 @@ pr: 15681
 host: harding
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/15681](https://github.com/bitcoin/bitcoin/pull/15681)
-
 ## Notes
 
 - A *child transaction* is a transaction that spends one or more of the
@@ -29,7 +27,7 @@ host: harding
   child transaction for inclusion in a block if all of its parents were
   either part of the block chain (confirmed) or already paid high-enough
   feerates to be included in the block proposal on their own.
-  
+
 - That old mining strategy doesn't maximize profits for miners: if a
   child transaction pays enough fees, the average feerate of mining both
   transactions can be higher than the feerate of the parent alone.  In
@@ -53,7 +51,7 @@ host: harding
   defaults to keeping up to about 100 blocks worth transactions in
   memory (several hundred thousand transactions), any of which might
   need to be updated when a new descendant arrives.
-  
+
 - To bound these costs, when CPFP mining (ancestor feerate mining) was
   implemented in [PR #7600][], it came with limits on the maximum number
   and size of related transactions that would be allowed into a
@@ -140,7 +138,7 @@ host: harding
 
 ```text
 12:59 < sosthene> Hi everyone
-13:00 < harding> Hi everyone.  John Newbery is off today, so I'll be hosting this week's meeting.  Let's get started by everyone saying hi and letting us know if you did any homework---read this week's PR, tried building it, read the notes at https://bitcoin-core-review-club.github.io/15681.html, read the mailing list discussion related to the PR, or did any other reviewing before the meeting (it's ok if 
+13:00 < harding> Hi everyone.  John Newbery is off today, so I'll be hosting this week's meeting.  Let's get started by everyone saying hi and letting us know if you did any homework---read this week's PR, tried building it, read the notes at https://bitcoin-core-review-club.github.io/15681.html, read the mailing list discussion related to the PR, or did any other reviewing before the meeting (it's ok if
 13:00 < harding> you didn't).
 13:00 < michaelfolkson> Hey
 13:00 < lightlike> hi

--- a/_posts/2019-06-26-#15681.md
+++ b/_posts/2019-06-26-#15681.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15681 Allow one extra single-ancestor transaction per package"
-component: mempool
+components: [mempool]
 pr: 15681
 host: harding
 ---

--- a/_posts/2019-07-03-#15443.md
+++ b/_posts/2019-07-03-#15443.md
@@ -6,8 +6,6 @@ pr: 15443
 host: jnewbery
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/15443](https://github.com/bitcoin/bitcoin/pull/15443)
-
 ## Notes
 
 - *Output script descriptor* are a language for describing individual
@@ -47,7 +45,7 @@ host: jnewbery
 
 - What is meant by *solvable* when talking about a descriptor?
 
-- Why are address and raw type descriptors always unsolvable? 
+- Why are address and raw type descriptors always unsolvable?
 
 ## Meeting Log
 

--- a/_posts/2019-07-03-#15443.md
+++ b/_posts/2019-07-03-#15443.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15443 Add getdescriptorinfo functional test"
-component: tests
+components: [tests]
 pr: 15443
 host: jnewbery
 ---

--- a/_posts/2019-07-10-#16244.md
+++ b/_posts/2019-07-10-#16244.md
@@ -6,8 +6,6 @@ pr: 16244
 host: jnewbery
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/16244](https://github.com/bitcoin/bitcoin/pull/16244)
-
 ## Notes
 
 - This is a small refactor PR which makes [PR 15450](https://github.com/bitcoin/bitcoin/pull/15450) (which [we reviewed a few weeks ago](https://bitcoin-core-review-club.github.io/15450.html)) simpler and cleaner.

--- a/_posts/2019-07-10-#16244.md
+++ b/_posts/2019-07-10-#16244.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#16244 Move wallet creation out of the createwallet rpc into its own function"
-component: wallet
+components: [wallet]
 pr: 16244
 host: jnewbery
 ---

--- a/_posts/2019-07-17-#15169.md
+++ b/_posts/2019-07-17-#15169.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15169 Parallelize CheckInputs() in AcceptToMemoryPool()"
-component: mempool
+components: [mempool]
 pr: 15169
 host: jachiang
 ---

--- a/_posts/2019-07-17-#15169.md
+++ b/_posts/2019-07-17-#15169.md
@@ -6,22 +6,20 @@ pr: 15169
 host: jachiang
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/15169](https://github.com/bitcoin/bitcoin/pull/15169)
-
 ## Notes
 
 * The [CheckInputs()](https://github.com/bitcoin/bitcoin/blob/8f9725c83f1da5364354d2820696c84d542d3d37/src/validation.cpp#L1234) function is called when checking the inputs to a transaction. Each input has a script which is verified. That verification can be run:
     - sequentially and synchronously, in which case `CheckInputs()` will return `true` if all scripts pass verification or pass back the error for the first script that failed verification; or
     - in parallel, in which case `CheckInputs()` will emplace the script check onto a queue for future verification.
 * Previously, `CheckInputs()` would always check inputs sequentially when accepting a transaction to the mempool. Transaction inputs [can](https://github.com/bitcoin/bitcoin/blob/8f604361ebaa5263e614c21570a3256e4dbc3bcc/src/init.cpp#L401) be checked in parallel during block validation. Note the [`vChecks` argument when calling `CheckInputs()` from `ConnectBlock()`](https://github.com/bitcoin/bitcoin/blob/8f9725c83f1da5364354d2820696c84d542d3d37/src/validation.cpp#L1887).
-* This PR enables the input checks to be performed in parallel when a transaction is entering the mempool. 
+* This PR enables the input checks to be performed in parallel when a transaction is entering the mempool.
 * It does so by replacing calls to `CheckInputs()` with [`RunCheckInputsMaybeParallel()`](https://github.com/bitcoin/bitcoin/commit/cb0c42cfda7669f3df57c167cf0d691f926039d2#diff-24efdb00bfbe56b140fb006b562cc70bR1679), which will push the input checks to an existing `CCheckQueue` worker queue.
   * [`CheckInputs`](https://github.com/bitcoin/bitcoin/blob/8f9725c83f1da5364354d2820696c84d542d3d37/src/validation.cpp#L1234)
   * [`CCheckQueue`](https://github.com/bitcoin/bitcoin/blob/8f9725c83f1da5364354d2820696c84d542d3d37/src/validation.cpp#L1528) (Currently used for block validation)
   * [Script check worker loop](https://github.com/bitcoin/bitcoin/blob/8f9725c83f1da5364354d2820696c84d542d3d37/src/checkqueue.h#L66) (Currently used for block validation)
 * There is a significant performance gain resulting from this optimization.
 * This PR also changes behavior when transactions are denied mempool acceptance. `RunCheckInputsMaybeParallel` (and by extension [`CheckInputs()`](https://github.com/bitcoin/bitcoin/commit/5f4e514412fc39e174f298a7737eb9f08a82a86b#diff-24efdb00bfbe56b140fb006b562cc70bL1436)) no longer set TX_NOT_STANDARD during input check failure, but only a consensus failure state.
-* Note: This has an effect on peer connections. 
+* Note: This has an effect on peer connections.
     * Current behaviour: A peer is disconnected when a consensus-invalid transaction is received, but remains connected if the transaction is only policy-invalid (non-standard).
     * Preposed behaviour: A peer is no longer disconnected, even if a consensus-invalid transaction is received.
 

--- a/_posts/2019-07-24-#15713.md
+++ b/_posts/2019-07-24-#15713.md
@@ -6,8 +6,6 @@ pr: 15713
 host: jnewbery
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/15713](https://github.com/bitcoin/bitcoin/pull/15713)
-
 ## Notes
 
 - The node-wallet interface was introduced in [PR

--- a/_posts/2019-07-24-#15713.md
+++ b/_posts/2019-07-24-#15713.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15713 refactor: Replace chain relayTransactions/submitMemoryPool by higher method"
-component: wallet
+components: [wallet]
 pr: 15713
 host: jnewbery
 ---

--- a/_posts/2019-07-31-#15505.md
+++ b/_posts/2019-07-31-#15505.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15505 Request NOTFOUND transactions immediately from other outbound peers, when possible"
-component: p2p
+components: [p2p]
 pr: 15505
 host: mzumsande
 ---

--- a/_posts/2019-07-31-#15505.md
+++ b/_posts/2019-07-31-#15505.md
@@ -6,8 +6,6 @@ pr: 15505
 host: mzumsande
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/15505](https://github.com/bitcoin/bitcoin/pull/15505)
-
 ## Notes
 - The basic message flow for transaction relay is `INV -> GETDATA -> TX`. A node that cannot deliver a requested transaction answers the `GETDATA` request with `NOTFOUND` instead of `TX`.
 - `NOTFOUND` messages were introduced in [Bitcoin Core PR 2192](https://github.com/bitcoin/bitcoin/pull/2192) and are documented in the [Bitcoin developer reference](https://btcinformation.org/en/developer-reference#notfound).

--- a/_posts/2019-08-07-#16345.md
+++ b/_posts/2019-08-07-#16345.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#16345 Add getblockbyheight method / #16439 support @height in place of blockhash for getblock etc"
-component: rpc
+components: [rpc]
 pr: 16345
 host: jnewbery
 ---

--- a/_posts/2019-08-14-#16115.md
+++ b/_posts/2019-08-14-#16115.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#16115 On bitcoind startup, write config args to debug.log"
-component: config
+components: [config]
 pr: 16115
 host: jnewbery
 ---

--- a/_posts/2019-08-14-#16115.md
+++ b/_posts/2019-08-14-#16115.md
@@ -6,8 +6,6 @@ pr: 16115
 host: jnewbery
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/16115](https://github.com/bitcoin/bitcoin/pull/16115)
-
 ## Notes
 
 - Configuration options can either be specified in a config file or passed as command-line arguments to the bitcoind or bitcoin-qt executable.

--- a/_posts/2019-08-21-#15931.md
+++ b/_posts/2019-08-21-#15931.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15931 Remove GetDepthInMainChain dependency on locked chain interface"
-component: wallet
+components: [wallet]
 pr: 15931
 host: jnewbery
 ---

--- a/_posts/2019-08-28-#15759.md
+++ b/_posts/2019-08-28-#15759.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15759 Add 2 outbound blocks-only connections"
-component: p2p
+components: [p2p]
 pr: 15759
 host: jnewbery
 ---

--- a/_posts/2019-08-28-#15759.md
+++ b/_posts/2019-08-28-#15759.md
@@ -6,8 +6,6 @@ pr: 15759
 host: jnewbery
 ---
 
-[https://github.com/bitcoin/bitcoin/pull/15759](https://github.com/bitcoin/bitcoin/pull/15759)
-
 ## Notes
 
 - The Bitcoin P2P network serves 3 purposes:

--- a/_posts/2019-09-04-#16512.md
+++ b/_posts/2019-09-04-#16512.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#16512 Shuffle inputs and outputs after joining psbts"
-component: rpc
+components: [rpc]
 pr: 16512
 host: jnewbery
 ---

--- a/_posts/2019-09-11-#16688.md
+++ b/_posts/2019-09-11-#16688.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#16688 log: Add validation interface logging"
-component: logging
+components: [logging]
 pr: 15204
 host: jkczyz
 ---

--- a/_posts/2019-09-18-#15204.md
+++ b/_posts/2019-09-18-#15204.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#15204 Add Open External Wallet action"
-component: gui
+components: [gui]
 pr: 15204
 host: jnewbery
 ---

--- a/_posts/2019-09-25-#16202.md
+++ b/_posts/2019-09-25-#16202.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#16202 Refactor network message deserialization"
-component: net processing
+components: [net processing]
 pr: 16202
 host: jonatack
 ---

--- a/_posts/2019-10-02-#16401.md
+++ b/_posts/2019-10-02-#16401.md
@@ -1,7 +1,7 @@
 ---
 layout: pr
 title: "#16401 Package relay"
-component: p2p
+components: [p2p]
 pr: 16401
 host: jonatack
 ---

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -51,3 +51,6 @@ a
 .host
   color: #828282
   font-size: 0.95em
+
+\:target
+  background: #ddd

--- a/index.html
+++ b/index.html
@@ -23,11 +23,16 @@ title: Home
     {% for post in site.posts reversed %}
     {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
     {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
+    {% capture components %}
+    {%- for comp in post.components -%}
+    <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %},{% endunless %}
+    {%- endfor -%}
+    {% endcapture %}
     {% if posttime >= nowunix %}
         <div class="Home-posts-post">
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }} ({{post.component}})</a>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
         </div>
     {%- endif -%}
     {% endfor %}
@@ -38,11 +43,16 @@ title: Home
     {% for post in site.posts limit: 5 %}
     {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
     {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
+    {% capture components %}
+    {%- for comp in post.components -%}
+    <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %},{% endunless %}
+    {%- endfor -%}
+    {% endcapture %}
     {% if posttime < nowunix %}
         <div class="Home-posts-post">
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }} ({{post.component}})</a>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
         </div>
     {%- endif -%}
     {% endfor %}

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@ title: Home
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
           <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
+	  <span class="host">hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a></span>
         </div>
     {%- endif -%}
     {% endfor %}
@@ -53,10 +54,11 @@ title: Home
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
           <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
+	  <span class="host">hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a></span>
         </div>
     {%- endif -%}
     {% endfor %}
-    <p>See all <a href="previous_meetings.html">previous meetings</a>.</p>
+    <p>See all <a href="meetings.html">previous meetings</a>.</p>
   </div>
 
   <h2>Other resources for new contributors</h2>

--- a/index.html
+++ b/index.html
@@ -2,21 +2,45 @@
 layout: default
 title: Home
 ---
+
 <div class="Home">
   <h1>A weekly review club for Bitcoin Core PRs</h1>
-    <p><em>All are welcome!</em></p>
-    <p>
-    We'll host a series of weekly review clubs on the #bitcoin-core-pr-reviews Freenode IRC channel at 17:00 UTC on Wednesdays. All are welcome to join and ask questions!<br/><br/>Reviewing and testing PRs is the best way to start contributing to Bitcoin Core, but it's difficult to know where to start. There are hundreds of open PRs, many require a lot of contextual knowledge, and contributors and reviewers often use unfamiliar terminology. This weekly IRC club is for people who want to help review Bitcoin Core PRs but find the process intimidating. Everyone is welcome to speak and questions are encouraged!<br/><br/>To take part, you should:
-    </p>
-    <ul>
-      <li>clone the repo, checkout and build the PR branch and run all tests</li>
-      <li>review the code changes and read the comments on the PR</li>
-      <li>make a note of any questions you want to ask</li>
-      <li>join the IRC channel at <strong>17:00 UTC on Wednesday</strong></li>
-    </ul>
-    <p>
+  <p>
+    <em>All are welcome!</em>
+  </p>
+  <p>
+    We'll host a series of weekly review clubs on the #bitcoin-core-pr-reviews
+    Freenode IRC channel at 17:00 UTC on Wednesdays. All are welcome to join and
+    ask questions!
+    <br>
+    <br>
+    Reviewing and testing PRs is the best way to start contributing to Bitcoin
+    Core, but it's difficult to know where to start. There are hundreds of open
+    PRs, many require a lot of contextual knowledge, and contributors and
+    reviewers often use unfamiliar terminology. This weekly IRC club is for
+    people who want to help review Bitcoin Core PRs but find the process
+    intimidating. Everyone is welcome to speak and questions are encouraged!
+    <br>
+    <br>
+    To take part, you should:
+  </p>
+  <ul>
+    <li>
+      clone the repo, checkout and build the PR branch and run all tests
+    </li>
+    <li>
+      review the code changes and read the comments on the PR
+    </li>
+    <li>
+      make a note of any questions you want to ask
+    </li>
+    <li>
+      join the IRC channel at <strong>17:00 UTC on Wednesday</strong>
+    </li>
+  </ul>
+  <p>
     The point of the review club is to give participants the tools and knowledge they need to take part in the Bitcoin Core review process on github. Inclusion of a PR in the review club is not an endorsement of the concept, approach or implementation in the PR!
-    </p>
+  </p>
 
   <div class="Home-posts">
     <h2 class="Home-posts-title">Upcoming meetings</h2>
@@ -29,16 +53,24 @@ title: Home
     {%- endfor -%}
     {% endcapture %}
     {% if posttime >= nowunix %}
-        <div class="Home-posts-post">
-          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
-          <span class="Home-posts-post-arrow">&raquo;</span>
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
-	  <span class="host">hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a></span>
-        </div>
+    <div class="Home-posts-post">
+      <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
+      <span class="Home-posts-post-arrow">&raquo;</span>
+      <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+      ({{components}})
+      <span class="host">hosted by
+        <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+      </span>
+    </div>
     {%- endif -%}
     {% endfor %}
 
-    <p>We're always looking for interesting PRs to discuss in review club and for volunteer hosts to lead the discussion. To suggest a PR or to offer to host a meeting, please leave a comment on <a href="https://github.com/bitcoin-core-review-club/bitcoin-core-review-club.github.io/issues/14">this github issue</a>.
+    <p>
+      We're always looking for interesting PRs to discuss in review club and for
+      volunteer hosts to lead the discussion. To suggest a PR or to offer to
+      host a meeting, please leave a comment on
+      <a href="https://github.com/bitcoin-core-review-club/bitcoin-core-review-club.github.io/issues/14">this github issue</a>.
+    </p>
 
     <h2 class="Home-posts-title">Previous meetings</h2>
     {% for post in site.posts limit: 5 %}
@@ -50,23 +82,52 @@ title: Home
     {%- endfor -%}
     {% endcapture %}
     {% if posttime < nowunix %}
-        <div class="Home-posts-post">
-          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
-          <span class="Home-posts-post-arrow">&raquo;</span>
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
-	  <span class="host">hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a></span>
-        </div>
+    <div class="Home-posts-post">
+      <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
+      <span class="Home-posts-post-arrow">&raquo;</span>
+      <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+      ({{components}})
+	    <span class="host">
+        hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+      </span>
+    </div>
     {%- endif -%}
     {% endfor %}
-    <p>See all <a href="meetings.html">previous meetings</a>.</p>
+    <p>
+      See all <a href="meetings.html">previous meetings</a>.
+    </p>
   </div>
 
   <h2>Other resources for new contributors</h2>
   <ul>
-    <li>Read the <a href="https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md">Contributing to Bitcoin Core Guide</a>. This will help you understand the process and some of the terminology we use in Bitcoin Core.</li>
-    <li>Look at the <a href="https://github.com/bitcoin/bitcoin/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">good first issues</a> and  <a href="https://github.com/bitcoin/bitcoin/issues?utf8=%E2%9C%93&q=label%3A%22Up+for+grabs%22">up for grabs</a> list.</li>
-    <li>Read the <a href="https://github.com/bitcoin/bitcoin/blob/master/doc/productivity.md">Bitcoin Core developer productivity tips</a>.</li>
-    <li>Brush up on your C++. There are <a href="https://stackoverflow.com/questions/388242/the-definitive-c-book-guide-and-list">many primers and reference manuals available</a>.</li>
-    <li>Blog posts on contributing to Bitcoin Core from <a href="https://bitcointechtalk.com/a-gentle-introduction-to-bitcoin-core-development-fdc95eaee6b8">Jimmy Song</a> and <a href="https://bitcointechtalk.com/contributing-to-bitcoin-core-a-personal-account-35f3a594340b">John Newbery</a>.</li>
+    <li>
+      Read the
+      <a href="https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md">Contributing
+        to Bitcoin Core Guide</a>.
+      This will help you understand the process and some of the terminology we use in Bitcoin Core.
+    </li>
+    <li>
+      Look at the
+      <a href="https://github.com/bitcoin/bitcoin/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">good
+        first issues</a> and
+      <a href="https://github.com/bitcoin/bitcoin/issues?utf8=%E2%9C%93&q=label%3A%22Up+for+grabs%22">up
+        for grabs</a> list.
+    </li>
+    <li>
+      Read the
+      <a href="https://github.com/bitcoin/bitcoin/blob/master/doc/productivity.md">Bitcoin
+        Core developer productivity tips</a>.
+    </li>
+    <li>
+      Brush up on your C++. There are
+      <a href="https://stackoverflow.com/questions/388242/the-definitive-c-book-guide-and-list">many
+        primers and reference manuals available</a>.
+    </li>
+    <li>
+      Blog posts on contributing to Bitcoin Core from
+      <a href="https://bitcointechtalk.com/a-gentle-introduction-to-bitcoin-core-development-fdc95eaee6b8">Jimmy Song</a>
+      and
+      <a href="https://bitcointechtalk.com/contributing-to-bitcoin-core-a-personal-account-35f3a594340b">John Newbery</a>.
+    </li>
   </ul>
 </div>

--- a/meetings-components.html
+++ b/meetings-components.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Previous Meetings
+title: Previous Meetings by Component
 ---
 
 {% capture raw_components %}
@@ -18,9 +18,9 @@ title: Previous Meetings
 {% assign components = raw_components | split: "|" | sort_natural | uniq %}
 
 <div class="Home">
-    <h2 class="Home-posts-title">Previous meetings</h2>
+    <h2 class="Home-posts-title">Previous meetings by component</h2>
     <p>{% include linkers/meetings-pages.md %}</p>
-    
+
     {% for component in components %}
     <h3 id="{{component}}">{{component}}</h3>
       <ul>

--- a/meetings-components.html
+++ b/meetings-components.html
@@ -26,23 +26,25 @@ title: Previous Meetings by Component
   </p>
 
 {% for component in components %}
-  <h3 id="{{component}}">
-    {{component}}
-  </h3>
-  <ul>
-    {% for post in site.posts %}
-    {% if post.components contains component %}
-    <li>
-      <div class="Home-posts-post">
-        <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
-        <span class="host">
-          hosted by
-          <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
-        </span>
-      </div>
-    </li>
-    {%- endif -%}
-    {% endfor %}
-  </ul>
+  <div id="{{component}}">
+    <h3>
+      {{component}}
+    </h3>
+    <ul>
+      {% for post in site.posts %}
+      {% if post.components contains component %}
+      <li>
+        <div class="Home-posts-post">
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+          <span class="host">
+            hosted by
+            <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+          </span>
+        </div>
+      </li>
+      {%- endif -%}
+      {% endfor %}
+    </ul>
+  </div>
 {% endfor %}
 </div>

--- a/meetings-components.html
+++ b/meetings-components.html
@@ -1,0 +1,37 @@
+---
+layout: default
+title: Previous Meetings
+---
+
+{% capture raw_components %}
+{%- for meeting in site.posts -%}
+  {%- if meeting.layout == 'pr' -%}
+    {%- if meeting.components == empty -%}
+      {% include ERROR_92_MISSING_TOPIC_CATEGORY %}
+    {%- endif -%}
+    {%- for component in meeting.components -%}
+      {{component}}|
+    {%- endfor -%}
+  {%- endif -%}
+{%- endfor -%}
+{% endcapture %}
+{% assign components = raw_components | split: "|" | sort_natural | uniq %}
+
+<div class="Home">
+    <h2 class="Home-posts-title">Previous meetings</h2>
+    <p>{% include linkers/meetings-pages.md %}</p>
+    
+    {% for component in components %}
+    <h3 id="{{component}}">{{component}}</h3>
+      <ul>
+      {% for post in site.posts %}
+      {% if post.components contains component %}
+        <li><div class="Home-posts-post">
+            <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+        </div></li>
+      {%- endif -%}
+      {% endfor %}
+      </ul>
+    {% endfor %}
+  </div>
+</div>

--- a/meetings-components.html
+++ b/meetings-components.html
@@ -18,7 +18,7 @@ title: Previous Meetings by Component
 {% assign components = raw_components | split: "|" | sort_natural | uniq %}
 
 <div class="Home">
-    <h2 class="Home-posts-title">Previous meetings by component</h2>
+    <h2 class="Home-posts-title">Previous meetings</h2>
     <p>{% include linkers/meetings-pages.md %}</p>
 
     {% for component in components %}
@@ -27,7 +27,8 @@ title: Previous Meetings by Component
       {% for post in site.posts %}
       {% if post.components contains component %}
         <li><div class="Home-posts-post">
-            <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+          <span class="host">hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a></span>
         </div></li>
       {%- endif -%}
       {% endfor %}

--- a/meetings-components.html
+++ b/meetings-components.html
@@ -18,21 +18,31 @@ title: Previous Meetings by Component
 {% assign components = raw_components | split: "|" | sort_natural | uniq %}
 
 <div class="Home">
-    <h2 class="Home-posts-title">Previous meetings</h2>
-    <p>{% include linkers/meetings-pages.md %}</p>
+  <h2 class="Home-posts-title">
+    Previous meetings
+  </h2>
+  <p>
+    {% include linkers/meetings-pages.md %}
+  </p>
 
-    {% for component in components %}
-    <h3 id="{{component}}">{{component}}</h3>
-      <ul>
-      {% for post in site.posts %}
-      {% if post.components contains component %}
-        <li><div class="Home-posts-post">
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
-          <span class="host">hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a></span>
-        </div></li>
-      {%- endif -%}
-      {% endfor %}
-      </ul>
+{% for component in components %}
+  <h3 id="{{component}}">
+    {{component}}
+  </h3>
+  <ul>
+    {% for post in site.posts %}
+    {% if post.components contains component %}
+    <li>
+      <div class="Home-posts-post">
+        <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+        <span class="host">
+          hosted by
+          <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+        </span>
+      </div>
+    </li>
+    {%- endif -%}
     {% endfor %}
-  </div>
+  </ul>
+{% endfor %}
 </div>

--- a/meetings-hosts.html
+++ b/meetings-hosts.html
@@ -1,0 +1,35 @@
+---
+layout: default
+title: Previous Meetings
+---
+
+{% capture raw_hosts %}
+{%- for meeting in site.posts -%}
+  {%- if meeting.layout == 'pr' -%}
+    {%- if meeting.host == empty -%}
+      {% include ERROR_92_MISSING_TOPIC_CATEGORY %}
+    {%- endif -%}
+    {{meeting.host}}|
+  {%- endif -%}
+{%- endfor -%}
+{% endcapture %}
+{% assign hosts = raw_hosts | split: "|" | sort_natural | uniq %}
+
+<div class="Home">
+    <h2 class="Home-posts-title">Previous meetings</h2>
+    <p>{% include linkers/meetings-pages.md %}</p>
+    
+    {% for host in hosts %}
+    <h3 id="{{host}}">{{host}}</h3>
+      <ul>
+      {% for post in site.posts %}
+      {% if post.host == host %}
+        <li><div class="Home-posts-post">
+            <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+        </div></li>
+      {%- endif -%}
+      {% endfor %}
+      </ul>
+    {% endfor %}
+  </div>
+</div>

--- a/meetings-hosts.html
+++ b/meetings-hosts.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Previous Meetings
+title: Previous Meetings by Host
 ---
 
 {% capture raw_hosts %}
@@ -16,9 +16,9 @@ title: Previous Meetings
 {% assign hosts = raw_hosts | split: "|" | sort_natural | uniq %}
 
 <div class="Home">
-    <h2 class="Home-posts-title">Previous meetings</h2>
+    <h2 class="Home-posts-title">Previous meetings by host (in alphabetical order)</h2>
     <p>{% include linkers/meetings-pages.md %}</p>
-    
+
     {% for host in hosts %}
     <h3 id="{{host}}">{{host}}</h3>
       <ul>

--- a/meetings-hosts.html
+++ b/meetings-hosts.html
@@ -25,28 +25,30 @@ title: Previous Meetings by Host
   </p>
 
 {% for host in hosts %}
-  <h3 id="{{host}}">
-    {{host}}
-    <a href="https://github.com/{{host}}"><i class="fa fa-github"></i></a>
-  </h3>
-  <ul>
-  {% for post in site.posts %}
-    {% capture components %}
-      {%- for comp in post.components -%}
-        <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
-      {%- endfor -%}
-    {% endcapture %}
-    {% if post.host == host %}
-    <li>
-      <div class="Home-posts-post">
-        <a class="Home-posts-post-title" href="{{ post.url }}">
-          {{ post.title }}
-        </a>
-        ({{components}})
-      </div>
-    </li>
-    {%- endif -%}
-  {% endfor %}
-  </ul>
+  <div id="{{host}}">
+    <h3>
+      {{host}}
+      <a href="https://github.com/{{host}}"><i class="fa fa-github"></i></a>
+    </h3>
+    <ul>
+    {% for post in site.posts %}
+      {% capture components %}
+        {%- for comp in post.components -%}
+          <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+        {%- endfor -%}
+      {% endcapture %}
+      {% if post.host == host %}
+      <li>
+        <div class="Home-posts-post">
+          <a class="Home-posts-post-title" href="{{ post.url }}">
+            {{ post.title }}
+          </a>
+          ({{components}})
+        </div>
+      </li>
+      {%- endif -%}
+    {% endfor %}
+    </ul>
+  </div>
 {% endfor %}
 </div>

--- a/meetings-hosts.html
+++ b/meetings-hosts.html
@@ -16,16 +16,21 @@ title: Previous Meetings by Host
 {% assign hosts = raw_hosts | split: "|" | sort_natural | uniq %}
 
 <div class="Home">
-    <h2 class="Home-posts-title">Previous meetings by host (in alphabetical order)</h2>
+    <h2 class="Home-posts-title">Previous meetings</h2>
     <p>{% include linkers/meetings-pages.md %}</p>
 
     {% for host in hosts %}
-    <h3 id="{{host}}">{{host}}</h3>
+    <h3 id="{{host}}">{{host}} <a href="https://github.com/{{host}}"><i class="fa fa-github"></i></a></h3>
       <ul>
       {% for post in site.posts %}
+      {% capture components %}
+      {%- for comp in post.components -%}
+      <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+      {%- endfor -%}
+      {% endcapture %}
       {% if post.host == host %}
         <li><div class="Home-posts-post">
-            <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
         </div></li>
       {%- endif -%}
       {% endfor %}

--- a/meetings-hosts.html
+++ b/meetings-hosts.html
@@ -4,37 +4,49 @@ title: Previous Meetings by Host
 ---
 
 {% capture raw_hosts %}
-{%- for meeting in site.posts -%}
-  {%- if meeting.layout == 'pr' -%}
-    {%- if meeting.host == empty -%}
-      {% include ERROR_92_MISSING_TOPIC_CATEGORY %}
+  {%- for meeting in site.posts -%}
+    {%- if meeting.layout == 'pr' -%}
+      {%- if meeting.host == empty -%}
+        {% include ERROR_92_MISSING_TOPIC_CATEGORY %}
+      {%- endif -%}
+      {{meeting.host}}|
     {%- endif -%}
-    {{meeting.host}}|
-  {%- endif -%}
-{%- endfor -%}
+  {%- endfor -%}
 {% endcapture %}
+
 {% assign hosts = raw_hosts | split: "|" | sort_natural | uniq %}
 
 <div class="Home">
-    <h2 class="Home-posts-title">Previous meetings</h2>
-    <p>{% include linkers/meetings-pages.md %}</p>
+  <h2 class="Home-posts-title">
+    Previous meetings
+  </h2>
+  <p>
+    {% include linkers/meetings-pages.md %}
+  </p>
 
-    {% for host in hosts %}
-    <h3 id="{{host}}">{{host}} <a href="https://github.com/{{host}}"><i class="fa fa-github"></i></a></h3>
-      <ul>
-      {% for post in site.posts %}
-      {% capture components %}
+{% for host in hosts %}
+  <h3 id="{{host}}">
+    {{host}}
+    <a href="https://github.com/{{host}}"><i class="fa fa-github"></i></a>
+  </h3>
+  <ul>
+  {% for post in site.posts %}
+    {% capture components %}
       {%- for comp in post.components -%}
-      <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+        <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
       {%- endfor -%}
-      {% endcapture %}
-      {% if post.host == host %}
-        <li><div class="Home-posts-post">
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
-        </div></li>
-      {%- endif -%}
-      {% endfor %}
-      </ul>
-    {% endfor %}
-  </div>
+    {% endcapture %}
+    {% if post.host == host %}
+    <li>
+      <div class="Home-posts-post">
+        <a class="Home-posts-post-title" href="{{ post.url }}">
+          {{ post.title }}
+        </a>
+        ({{components}})
+      </div>
+    </li>
+    {%- endif -%}
+  {% endfor %}
+  </ul>
+{% endfor %}
 </div>

--- a/meetings.html
+++ b/meetings.html
@@ -1,10 +1,9 @@
 ---
 layout: default
-title: Previous Meetings
+title: Previous Meetings by Date
 ---
-
 <div class="Home">
-    <h2 class="Home-posts-title">Previous meetings</h2>
+    <h2 class="Home-posts-title">Previous meetings by date</h2>
     <p>{% include linkers/meetings-pages.md %}</p>
     {% for post in site.posts %}
     {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}

--- a/meetings.html
+++ b/meetings.html
@@ -2,16 +2,23 @@
 layout: default
 title: Previous Meetings
 ---
+
 <div class="Home">
     <h2 class="Home-posts-title">Previous meetings</h2>
+    <p>{% include linkers/meetings-pages.md %}</p>
     {% for post in site.posts %}
     {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
     {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
+    {% capture components %}
+    {%- for comp in post.components -%}
+    <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+    {%- endfor -%}
+    {% endcapture %}
     {% if posttime < nowunix %}
         <div class="Home-posts-post">
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }} ({{ post.component }})</a>
+          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
         </div>
     {%- endif -%}
     {% endfor %}

--- a/meetings.html
+++ b/meetings.html
@@ -3,7 +3,7 @@ layout: default
 title: Previous Meetings by Date
 ---
 <div class="Home">
-    <h2 class="Home-posts-title">Previous meetings by date</h2>
+    <h2 class="Home-posts-title">Previous meetings</h2>
     <p>{% include linkers/meetings-pages.md %}</p>
     {% for post in site.posts %}
     {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
@@ -18,6 +18,7 @@ title: Previous Meetings by Date
           <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
           <span class="Home-posts-post-arrow">&raquo;</span>
           <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
+	  <span class="host">hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a></span>
         </div>
     {%- endif -%}
     {% endfor %}

--- a/meetings.html
+++ b/meetings.html
@@ -2,25 +2,40 @@
 layout: default
 title: Previous Meetings by Date
 ---
+
 <div class="Home">
-    <h2 class="Home-posts-title">Previous meetings</h2>
-    <p>{% include linkers/meetings-pages.md %}</p>
-    {% for post in site.posts %}
-    {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
-    {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
-    {% capture components %}
+  <h2 class="Home-posts-title">
+    Previous meetings
+  </h2>
+  <p>
+    {% include linkers/meetings-pages.md %}
+  </p>
+
+{% for post in site.posts %}
+  {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
+  {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
+
+  {% capture components %}
     {%- for comp in post.components -%}
-    <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+      <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
     {%- endfor -%}
-    {% endcapture %}
-    {% if posttime < nowunix %}
-        <div class="Home-posts-post">
-          <span class="Home-posts-post-date">{{ post.date | date_to_string }}</span>
-          <span class="Home-posts-post-arrow">&raquo;</span>
-          <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a> ({{components}})
-	  <span class="host">hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a></span>
-        </div>
-    {%- endif -%}
-    {% endfor %}
+  {% endcapture %}
+
+  {% if posttime < nowunix %}
+  <div class="Home-posts-post">
+    <span class="Home-posts-post-date">
+      {{ post.date | date_to_string }}
+    </span>
+    <span class="Home-posts-post-arrow">
+      &raquo;
+    </span>
+    <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
+    ({{components}})
+    <span class="host">
+      hosted by
+      <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+    </span>
   </div>
+  {%- endif -%}
+{% endfor %}
 </div>


### PR DESCRIPTION
Adds `/meetings-components` and `/meetings-hosts` which list the meetings by component and host, respectively.

Other small changes:

- previous_meetings is renamed to meetings
- the page.component tag is changed to page.components so a meeting can be tagged as more than one component. PR 10823 is restored to `mempool` and `policy` (which is what it was listed under prior to #21

Resolves #25