### PR TITLE
Remove trailing slashes from links to meeting pages

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -7,7 +7,7 @@ author:
 menu:
 # Uncomment to activate the menu looping function in the header.html file under _includes
 - {name: 'Home', url: ''}
-- {name: 'Meetings', url: 'meetings.html'}
+- {name: 'Meetings', url: '/meetings'}
 
 social:
 # Uncomment to activate the social media icon looping function in the footer.html file under _includes

--- a/_includes/linkers/meetings-pages.md
+++ b/_includes/linkers/meetings-pages.md
@@ -3,17 +3,17 @@
 {% if path == "meetings" %}
   {% assign _index_links = _index_links | append: "<strong>by date</strong>" %}
 {% else %}
-  {% assign _index_links = _index_links | append: "<a href='/meetings/'>by date</a>" %}
+  {% assign _index_links = _index_links | append: "<a href='/meetings'>by date</a>" %}
 {% endif %}
 {% if path == "meetings-components" %}
   {% assign _index_links = _index_links | append: " | <strong>by component</strong>" %}
 {% else %}
-  {% assign _index_links = _index_links | append: " | <a href='/meetings-components/'>by component</a>" %}
+  {% assign _index_links = _index_links | append: " | <a href='/meetings-components'>by component</a>" %}
 {% endif %}
 {% if path == "meetings-hosts" %}
   {% assign _index_links = _index_links | append: " | <strong>by host</strong>" %}
 {% else %}
-  {% assign _index_links = _index_links | append: " | <a href='/meetings-hosts/'>by host</a>" %}
+  {% assign _index_links = _index_links | append: " | <a href='/meetings-hosts'>by host</a>" %}
 {% endif %}
 {% endcapture %}
 | {{_index_links}} |

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -4,7 +4,7 @@ layout: default
 
 {% capture components %}
   {%- for comp in page.components -%}
-    <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+    <a href="/meetings-components#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
   {%- endfor -%}
 {% endcapture %}
 
@@ -22,7 +22,7 @@ layout: default
     </p>
     <p class="host">
       Host:
-      <a class="host" href="/meetings-hosts/#{{ page.host }}">{{ page.host }}</a>
+      <a class="host" href="/meetings-hosts#{{ page.host }}">{{ page.host }}</a>
       <a href="https://github.com/{{ page.host }}">
         <i class="fa fa-github"></i>
       </a>

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@ title: Home
     {%- endif -%}
     {% endfor %}
     <p>
-      See all <a href="meetings.html">previous meetings</a>.
+      See all <a href="/meetings">previous meetings</a>.
     </p>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ title: Home
     {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
     {% capture components %}
     {%- for comp in post.components -%}
-    <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %},{% endunless %}
+    <a href="/meetings-components#{{comp}}">{{comp}}</a>{% unless forloop.last %},{% endunless %}
     {%- endfor -%}
     {% endcapture %}
     {% if posttime >= nowunix %}
@@ -59,7 +59,7 @@ title: Home
       <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
       ({{components}})
       <span class="host">hosted by
-        <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+        <a class="host" href="/meetings-hosts#{{post.host}}">{{ post.host }}</a>
       </span>
     </div>
     {%- endif -%}
@@ -78,7 +78,7 @@ title: Home
     {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
     {% capture components %}
     {%- for comp in post.components -%}
-    <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %},{% endunless %}
+    <a href="/meetings-components#{{comp}}">{{comp}}</a>{% unless forloop.last %},{% endunless %}
     {%- endfor -%}
     {% endcapture %}
     {% if posttime < nowunix %}
@@ -88,7 +88,7 @@ title: Home
       <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
       ({{components}})
 	    <span class="host">
-        hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+        hosted by <a class="host" href="/meetings-hosts#{{post.host}}">{{ post.host }}</a>
       </span>
     </div>
     {%- endif -%}

--- a/meetings-components.html
+++ b/meetings-components.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Previous Meetings by Component
+permalink: /meetings-components/
 ---
 
 {% capture raw_components %}

--- a/meetings-components.html
+++ b/meetings-components.html
@@ -38,7 +38,7 @@ title: Previous Meetings by Component
           <a class="Home-posts-post-title" href="{{ post.url }}">{{ post.title }}</a>
           <span class="host">
             hosted by
-            <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+            <a class="host" href="/meetings-hosts#{{post.host}}">{{ post.host }}</a>
           </span>
         </div>
       </li>

--- a/meetings-hosts.html
+++ b/meetings-hosts.html
@@ -34,7 +34,7 @@ title: Previous Meetings by Host
     {% for post in site.posts %}
       {% capture components %}
         {%- for comp in post.components -%}
-          <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+          <a href="/meetings-components#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
         {%- endfor -%}
       {% endcapture %}
       {% if post.host == host %}

--- a/meetings-hosts.html
+++ b/meetings-hosts.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Previous Meetings by Host
+permalink: /meetings-hosts/
 ---
 
 {% capture raw_hosts %}

--- a/meetings.html
+++ b/meetings.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Previous Meetings by Date
+permalink: /meetings/
 ---
 
 <div class="Home">

--- a/meetings.html
+++ b/meetings.html
@@ -17,7 +17,7 @@ title: Previous Meetings by Date
 
   {% capture components %}
     {%- for comp in post.components -%}
-      <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+      <a href="/meetings-components#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
     {%- endfor -%}
   {% endcapture %}
 
@@ -33,7 +33,7 @@ title: Previous Meetings by Date
     ({{components}})
     <span class="host">
       hosted by
-      <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+      <a class="host" href="/meetings-hosts#{{post.host}}">{{ post.host }}</a>
     </span>
   </div>
   {%- endif -%}


### PR DESCRIPTION
as a follow-up patch to #28 for 404s seen only in production.