### PR TITLE
Update the meeting listings headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ title: Home
       <a href="https://github.com/bitcoin-core-review-club/bitcoin-core-review-club.github.io/issues/14">this github issue</a>.
     </p>
 
-    <h2 class="Home-posts-title">Previous meetings</h2>
+    <h2 class="Home-posts-title">Recent meetings</h2>
     {% for post in site.posts limit: 5 %}
     {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
     {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
@@ -94,7 +94,7 @@ title: Home
     {%- endif -%}
     {% endfor %}
     <p>
-      See all <a href="/meetings/">previous meetings</a>.
+      See all <a href="/meetings/">meetings</a>.
     </p>
   </div>
 

--- a/meetings-components.html
+++ b/meetings-components.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Previous Meetings by Component
+title: Meetings by Component
 permalink: /meetings-components/
 ---
 
@@ -20,7 +20,7 @@ permalink: /meetings-components/
 
 <div class="Home">
   <h2 class="Home-posts-title">
-    Previous meetings
+    Meetings
   </h2>
   <p>
     {% include linkers/meetings-pages.md %}

--- a/meetings-hosts.html
+++ b/meetings-hosts.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Previous Meetings by Host
+title: Meetings by Host
 permalink: /meetings-hosts/
 ---
 
@@ -19,7 +19,7 @@ permalink: /meetings-hosts/
 
 <div class="Home">
   <h2 class="Home-posts-title">
-    Previous meetings
+    Meetings
   </h2>
   <p>
     {% include linkers/meetings-pages.md %}

--- a/meetings.html
+++ b/meetings.html
@@ -1,28 +1,24 @@
 ---
 layout: default
-title: Previous Meetings by Date
+title: Meetings by Date
 permalink: /meetings/
 ---
 
 <div class="Home">
   <h2 class="Home-posts-title">
-    Previous meetings
+    Meetings
   </h2>
   <p>
     {% include linkers/meetings-pages.md %}
   </p>
 
 {% for post in site.posts %}
-  {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
-  {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
-
   {% capture components %}
     {%- for comp in post.components -%}
       <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
     {%- endfor -%}
   {% endcapture %}
 
-  {% if posttime < nowunix %}
   <div class="Home-posts-post">
     <span class="Home-posts-post-date">
       {{ post.date | date_to_string }}
@@ -37,6 +33,5 @@ permalink: /meetings/
       <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
     </span>
   </div>
-  {%- endif -%}
 {% endfor %}
 </div>


### PR DESCRIPTION
1. Fix the meetings-components and meetings-hosts header from "Previous meetings" to "Meetings" since they list all meetings.

2. In the meetings by date page, list all of the meetings instead of the past ones, to keep the meetings listings consistent.

3. In the home page, above the listing of the last 4 meetings, change the title from "Previous meetings" to "Recent meetings", and update the "See all previous meetings" to "See all meetings".

This PR should make everything consistent for now, while figuring out how the site will evolve.