### PR TITLE
Add authors index

### DIFF
--- a/_includes/linkers/meetings-pages.md
+++ b/_includes/linkers/meetings-pages.md
@@ -1,19 +1,30 @@
 {% capture /dev/null %}
+
 {% assign path = page.path | remove: ".html" %}
+
 {% if path == "meetings" %}
   {% assign _index_links = _index_links | append: "<strong>by date</strong>" %}
 {% else %}
   {% assign _index_links = _index_links | append: "<a href='/meetings/'>by date</a>" %}
 {% endif %}
+
 {% if path == "meetings-components" %}
   {% assign _index_links = _index_links | append: " | <strong>by component</strong>" %}
 {% else %}
   {% assign _index_links = _index_links | append: " | <a href='/meetings-components/'>by component</a>" %}
 {% endif %}
+
 {% if path == "meetings-hosts" %}
   {% assign _index_links = _index_links | append: " | <strong>by host</strong>" %}
 {% else %}
   {% assign _index_links = _index_links | append: " | <a href='/meetings-hosts/'>by host</a>" %}
 {% endif %}
+
+{% if path == "meetings-authors" %}
+  {% assign _index_links = _index_links | append: " | <strong>by author</strong>" %}
+{% else %}
+  {% assign _index_links = _index_links | append: " | <a href='/meetings-authors/'>by author</a>" %}
+{% endif %}
+
 {% endcapture %}
 | {{_index_links}} |

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -8,9 +8,18 @@ layout: default
   {%- endfor -%}
 {% endcapture %}
 
+{% capture authors %}
+  {%- for author in page.authors -%}
+    <a class="author" href="/meetings-authors/#{{author}}">{{author}}</a>
+    <a href="https://github.com/{{ author }}"><i class="fa fa-github"></i></a>
+    {% unless forloop.last %}, {% endunless %}
+  {%- endfor -%}
+{% endcapture %}
+
 <section>
   <div class="post-content">
     <h1>{{ page.title }} ({{components}})</h1>
+
     <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">
       {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
       {{ page.date | date: date_format }}
@@ -20,23 +29,31 @@ layout: default
         {{ site.meeting_location }}
       {%- endif -%}
     </time>
+
     <p style="font-weight:bold">
       <a href="https://github.com/bitcoin/bitcoin/pull/{{ page.pr }}">
         https://github.com/bitcoin/bitcoin/{{ page.pr }}
       </a>
     </p>
+
     <p class="host">
       Host:
       <a class="host" href="/meetings-hosts/#{{ page.host }}">{{ page.host }}</a>
-      <a href="https://github.com/{{ page.host }}">
-        <i class="fa fa-github"></i>
-      </a>
+      <a href="https://github.com/{{ page.host }}"><i class="fa fa-github"></i></a>
+    {% unless authors == empty %}
+      &nbsp;-&nbsp;
+      <span class="author">
+        PR author{% if page.authors.size > 1 %}s{% endif %}: {{authors}}
+      </span>
+    {%- endunless -%}
     </p>
+
     {% if page.status == "past" %}
       {% if page.commit %}
       <p><em>The PR branch HEAD was <a href="https://github.com/bitcoin-core-review-club/bitcoin/tree/pr{{ page.pr }}/">{{ page.commit }}</a> at the time of this review club meeting.</em><p>
       {%- endif -%}
     {%- endif -%}
+
     <p>
       {{ content }}
     </p>

--- a/_posts/2019-05-01-#15557.md
+++ b/_posts/2019-05-01-#15557.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Enhance bumpfee to include inputs when targeting a feerate"
 components: [wallet]
 pr: 15557
+authors: [instagibbs]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-05-08-#10823.md
+++ b/_posts/2019-05-08-#10823.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Allow all mempool txs to be replaced after a configurable timeout (default 6h)"
 components: [mempool, policy]
 pr: 10823
+authors: [greenaddress]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-05-15-#15834.md
+++ b/_posts/2019-05-15-#15834.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Fix NOTFOUND bug and expire getdata requests for transactions"
 components: [net processing]
 pr: 15834
+authors: [sdaftuar]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-05-22-#15450.md
+++ b/_posts/2019-05-22-#15450.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Create wallet menu option"
 components: [gui]
 pr: 15450
+authors: [achow101]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-05-29-#15741.md
+++ b/_posts/2019-05-29-#15741.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Batch write imported stuff in importmulti"
 components: [wallet]
 pr: 15741
+authors: [achow101]
 host: ariard
 status: past
 ---

--- a/_posts/2019-06-05-#16060.md
+++ b/_posts/2019-06-05-#16060.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Bury bip9 deployments"
 components: [consensus]
 pr: 16060
+authors: [jnewbery]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-06-12-#15996.md
+++ b/_posts/2019-06-12-#15996.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Deprecate totalfee argument in `bumpfee`"
 components: [rpc]
 pr: 15996
+authors: [instagibbs]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-06-19-#15481.md
+++ b/_posts/2019-06-19-#15481.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Restrict timestamp when mining a diff-adjustment block to prev-600"
 components: [mining]
 pr: 15481
+authors: [TheBlueMatt]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-06-26-#15681.md
+++ b/_posts/2019-06-26-#15681.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Allow one extra single-ancestor transaction per package"
 components: [mempool]
 pr: 15681
+authors: [TheBlueMatt]
 host: harding
 status: past
 ---

--- a/_posts/2019-07-03-#15443.md
+++ b/_posts/2019-07-03-#15443.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Add getdescriptorinfo functional test"
 components: [tests]
 pr: 15443
+authors: [promag]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-07-10-#16244.md
+++ b/_posts/2019-07-10-#16244.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Move wallet creation out of the createwallet rpc into its own function"
 components: [wallet]
 pr: 16244
+authors: [achow101]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-07-17-#15169.md
+++ b/_posts/2019-07-17-#15169.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Parallelize CheckInputs() in AcceptToMemoryPool()"
 components: [mempool]
 pr: 15169
+authors: [sdaftuar]
 host: jachiang
 status: past
 ---

--- a/_posts/2019-07-24-#15713.md
+++ b/_posts/2019-07-24-#15713.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Replace chain relayTransactions/submitMemoryPool by higher method"
 components: [wallet]
 pr: 15713
+authors: [ariard]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-07-31-#15505.md
+++ b/_posts/2019-07-31-#15505.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Request NOTFOUND transactions immediately from other outbound peers, when possible"
 components: [p2p]
 pr: 15505
+authors: [sdaftuar]
 host: mzumsande
 status: past
 ---

--- a/_posts/2019-08-07-#16345.md
+++ b/_posts/2019-08-07-#16345.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Add getblockbyheight method / support @height in place of blockhash for getblock etc"
 components: [rpc]
 pr: 16345
+authors: [emilengler]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-08-14-#16115.md
+++ b/_posts/2019-08-14-#16115.md
@@ -3,6 +3,7 @@ layout: pr
 title: "On bitcoind startup, write config args to debug.log"
 components: [config]
 pr: 16115
+authors: [LarryRuane]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-08-21-#15931.md
+++ b/_posts/2019-08-21-#15931.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Remove GetDepthInMainChain dependency on locked chain interface"
 components: [wallet]
 pr: 15931
+authors: [ariard]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-08-28-#15759.md
+++ b/_posts/2019-08-28-#15759.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Add 2 outbound blocks-only connections"
 components: [p2p]
 pr: 15759
+authors: [sdaftuar]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-09-04-#16512.md
+++ b/_posts/2019-09-04-#16512.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Shuffle inputs and outputs after joining psbts"
 components: [rpc]
 pr: 16512
+authors: [achow101]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-09-11-#16688.md
+++ b/_posts/2019-09-11-#16688.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Add validation interface logging"
 components: [logging]
 pr: 16688
+authors: [jkczyz]
 host: jkczyz
 status: past
 ---

--- a/_posts/2019-09-18-#15204.md
+++ b/_posts/2019-09-18-#15204.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Add Open External Wallet action"
 components: [gui]
 pr: 15204
+authors: [promag]
 host: jnewbery
 status: past
 ---

--- a/_posts/2019-09-25-#16202.md
+++ b/_posts/2019-09-25-#16202.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Refactor network message deserialization"
 components: [net processing]
 pr: 16202
+authors: [jonasschnelli]
 host: jonatack
 status: past
 ---

--- a/_posts/2019-10-02-#16401.md
+++ b/_posts/2019-10-02-#16401.md
@@ -3,6 +3,7 @@ layout: pr
 title: "Package relay"
 components: [p2p]
 pr: 16401
+authors: [sdaftuar]
 host: jonatack
 status: past
 ---

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -47,6 +47,10 @@ a
   color: #828282
   font-size: 0.95em
 
+.author
+  color: #828282
+  font-size: 0.95em
+
 \:target
   background: #ddd
 

--- a/meetings-authors.html
+++ b/meetings-authors.html
@@ -1,0 +1,58 @@
+---
+layout: default
+title: Meetings by Author
+permalink: /meetings-authors/
+---
+
+{% capture raw_authors %}
+  {%- for meeting in site.posts -%}
+    {%- if meeting.layout == 'pr' -%}
+      {%- if meeting.authors == empty -%}
+        {% include ERROR_92_MISSING_TOPIC_CATEGORY %}
+      {%- endif -%}
+      {%- for author in meeting.authors -%}
+        {{author}}|
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endfor -%}
+{% endcapture %}
+
+{% assign authors = raw_authors | split: "|" | sort_natural | uniq %}
+
+<div class="Home">
+  <h2 class="Home-posts-title">Meetings</h2>
+  <p>{% include linkers/meetings-pages.md %}</p>
+
+  {% for author in authors %}
+    <div id="{{author}}">
+      <h3 class="meetings-index-section">
+        {{author}}
+        <a href="https://github.com/{{author}}"><i class="fa fa-github"></i></a>
+      </h3>
+      <table style="padding-left: 1.5em">
+        {% for post in site.posts %}
+          {% capture components %}
+            {%- for comp in post.components -%}
+              <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+            {%- endfor -%}
+          {% endcapture %}
+          {% if post.authors contains author %}
+            <tr class="Home-posts-post">
+              <td class="Home-posts-post-date">
+                {{ post.date | date_to_string }}
+              </td>
+              <td class="Home-posts-post-arrow">
+                &raquo;
+              </td>
+              <td>
+                <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
+                ({{components}})
+              </td>
+            </tr>
+          {%- endif -%}
+        {% endfor %}
+      </table>
+    </div>
+  {% endfor %}
+</div>
+<br>


### PR DESCRIPTION
Adds a `meetings-authors` page to allow seeing PRs sorted by author. This was my motivation for this feature. It's basically a mix of the work already done for the components and hosts.

Added authors to 4 of the meetings for testing.

Handles one or multiple authors per PR.

Displays the authors in the PR layout if any are present, with links to the author's PRs and GitHub, like for meeting hosts.