### PR TITLE
Add test setup and test all site links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,13 @@ gem "jekyll-sitemap", "~> 1.3"
 gem "jekyll-feed", "~> 0.12.1"
 gem "jekyll-seo-tag", "~> 2.6"
 
-# Ruby Make
+# Ruby make
 gem 'rake'
+
+# Testing
+gem 'minitest'
+gem 'minitest-reporters'
+gem 'color_pound_spec_reporter'
+
+# HTTP bindings to libcurl - https://github.com/taf2/curb
+gem 'curb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,3 @@ DEPENDENCIES
   minitest
   minitest-reporters
   rake
-
-BUNDLED WITH
-   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,16 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ansi (1.5.0)
+    builder (3.2.4)
+    color_pound_spec_reporter (0.0.9)
+      bundler
+      minitest
+      minitest-reporters (>= 0.14.24)
+      rake
     colorator (1.1.0)
     concurrent-ruby (1.1.5)
+    curb (0.9.10)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -44,6 +52,12 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    minitest (5.14.0)
+    minitest-reporters (1.4.2)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.1)
@@ -52,6 +66,7 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rouge (3.11.1)
+    ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -63,9 +78,16 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  color_pound_spec_reporter
+  curb
   jekyll (~> 3.8)
   jekyll-feed (~> 0.12.1)
   jekyll-paginate (~> 1.1)
   jekyll-seo-tag (~> 2.6)
   jekyll-sitemap (~> 1.3)
+  minitest
+  minitest-reporters
   rake
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -28,10 +28,8 @@ To run one test file: `rake TEST=test/test_rake_posts_new`
 To run an individual test in a test file:
 `rake TEST=test/test_rake_posts_new TESTOPTS=--name=test_rake_posts_new`
 
-Before running tests for the first time, you may need to run:
-```
-$ bundle update && gem install curb
-```
+Before running tests for the first time, you may need to run `bundle update`.
+
 Before running the `test_all_links` test (or all of the tests, which includes
 it), the site needs to be started up locally with `make preview`, or with `make
 clean preview` if any meeting logs were changed, to pre-render the logs through

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ See the [CONTRIBUTING.md](CONTRIBUTING.md) doc for how to create a post for an u
 
 All site configurations are either contained in `_config.yml` or `_data/settings.yml`. Some data is duplicated between the two due to the way Jekyll injects variables, so be sure to update both.
 
+## Running the Test Suite
+
+To run all tests: `rake test` or just `rake`
+
+To run one test file: `rake TEST=test/test_rake_posts_new`
+
+To run an individual test in a test file:
+`rake TEST=test/test_rake_posts_new TESTOPTS=--name=test_rake_posts_new`
+
+Before running tests for the first time, you may need to run:
+```
+$ bundle update && gem install curb
+```
+Before running the `test_all_links` test (or all of the tests, which includes
+it), the site needs to be started up locally with `make preview`, or with `make
+clean preview` if any meeting logs were changed, to pre-render the logs through
+the `auto_logs_markup` plugin.
 
 ## Attributions
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,22 @@ require 'date'
 require 'json'
 require 'net/http'
 require 'optparse'
+require 'rake/testtask'
+
+# To run all tests:
+#   rake (or) rake test
+#
+# To run one test file:
+#   rake test TEST=test/FILENAME
+#
+# To run an individual test in a test file:
+#   rake test TEST=test/FILENAME TESTOPTS=--name=TEST_NAME
+#
+desc 'Run all tests with `rake` or `rake test`'
+task default: :test # Make test runner the default rake task.
+Rake::TestTask.new do |task|
+  task.pattern = 'test/test_*.rb'
+end
 
 # These correspond to the GitHub labels used by Bitcoin Core.
 DESIRED_COMPONENTS = [

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# test/test_helper.rb - This test setup helper is required by each test file.
+
+# Load test runner.
+require 'minitest/autorun'
+
+# Load test reporter.
+require 'color_pound_spec_reporter'
+Minitest::Reporters.use! [ColorPoundSpecReporter.new]

--- a/test/test_rake_posts_new.rb
+++ b/test/test_rake_posts_new.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class TestRakePostsNew < Minitest::Test
+  def test_rake_posts_new
+    assert true
+  end
+end

--- a/test/test_site_content.rb
+++ b/test/test_site_content.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+require 'curb'
+require 'uri'
+
+class TestSiteContent < Minitest::Test
+  # Load content from site XML feed, either in production, or locally after
+  # running `make preview`, and run tests on the content.
+  #
+  # To run only this test file: rake TEST=test/test_site_content
+
+  # Uncomment the desired website url:
+  # SITE = 'https://bitcoincore.reviews'
+  SITE = 'localhost:4000'
+  URI_SCHEMES = %w(http https).freeze
+  HTTP_SUCCESS = 200
+  HTTP_ERROR = 400
+  # Regex to select all trailing punctuation except "/".
+  TRAILING_PUNCTUATION = /[^\/[:^punct:]]+$/
+
+  def setup
+    http = Curl.get("#{SITE}/feed.xml")
+    assert_equal HTTP_SUCCESS, http.response_code
+    @body = http.body
+  end
+
+  def test_all_links
+    # Check the HTTP status of all URLs in the site-wide XML feed.
+    # To run only this test:
+    # rake TEST=test/test_site_content TESTOPTS=--name=test_all_links
+
+    # Scrape potential links.
+    urls = URI.extract(@body, schemes = URI_SCHEMES).uniq
+
+    # Strip any trailing wierdness.
+    urls.each_with_index do |url, index|
+      str = url.sub(TRAILING_PUNCTUATION, '')
+      parts = str.split('&')
+      str = parts.first if parts.size > 1
+      urls[index] = str
+    end
+
+    urls.uniq!
+    total, errors = urls.count, 0
+
+    # Test the links...
+    puts "#{total} unique links found, now testing..."
+    puts '  count  |  status   |  url'
+
+    urls.each.with_index(1) do |url, index|
+      count = "#{' ' * (total.to_s.size - index.to_s.size)}#{index}"
+      status = Curl.get(url).response_code
+
+      if status == HTTP_SUCCESS
+        puts "#{count}/#{total}  |    #{status}    |  #{url}"
+      else
+        puts "#{count}/#{total}  |  **#{status}**  |  #{url}"
+        errors += 1 if status >= HTTP_ERROR
+      end
+    end
+    assert_equal 0, errors
+  end
+end


### PR DESCRIPTION
TL|DR:
```
$ bundle update && gem install curb
$ make preview (if running the links test on the local server) 
$ rake
```
This PR sets up testing in a minimal way using Minitest, a simple, fast, tiny mini-framework in pure Ruby with no magic or DSL. It also adds a pretty test reporter because it's much nicer and a tiny dependency.

This allows running the tests from the command line with `rake test` or simply `rake`. Individual test files or cases can be run as well as per the comments in the Rakefile. There are integrations available for various editors, including vim and emacs, to run this from within the editor environment. 

--------
NEW: Added a test to check all the links in the site -- either locally after running `make preview` (default), or on the website in production, and display a report in the terminal.