### PR TITLE
Add undesired labels to `rake posts:new` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,14 @@ require 'net/http'
 require 'optparse'
 
 UNDESIRED_LABELS = [
-  'refactoring', 'needs conceptual review', 'needs rebase', 'waiting for author'
+  'feature',
+  'needs conceptual review',
+  'needs rebase',
+  'refactor',
+  'refactoring',
+  'waiting for author',
 ].freeze
+
 GITHUB_API_URL = 'https://api.github.com/repos/bitcoin/bitcoin/pulls'
 HTTP_SUCCESS  = '200'
 HTTP_NOTFOUND = '404'


### PR DESCRIPTION
Added 'feature' and 'refactor' to the undesired labels array, after noticing while adding n16702 that these were ending up in the components array. Any others to add?
