### PR TITLE
Meetings pages improvements

### DIFF
--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -57,3 +57,8 @@ a
 .question
   font-size: 1.2em
   font-weight: bold
+
+.month
+  margin-top: 0.4em
+  margin-bottom: 0.4em
+  color: #606060

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -62,3 +62,6 @@ a
   margin-top: 0.4em
   margin-bottom: 0.4em
   color: #606060
+
+.Home-posts-post-date
+  min-width: 94px

--- a/assets/css/all.sass
+++ b/assets/css/all.sass
@@ -65,3 +65,6 @@ a
 
 .Home-posts-post-date
   min-width: 94px
+
+.Home-posts-post-arrow
+  padding-right: 4px

--- a/index.md
+++ b/index.md
@@ -41,24 +41,30 @@ Core contributors. See some of our [previous hosts](/meetings-hosts/).
 
 ## Upcoming Meetings
 
+<table>
 {% for post in site.posts reversed %}
   {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
   {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
   {% capture components %}
-    {%- for comp in post.components -%}
-      <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
-    {%- endfor -%}
+  {%- for comp in post.components -%}
+    <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+  {%- endfor -%}
   {% endcapture %}
-  {% if posttime >= nowunix %}<div class="home-posts-post">
-    <span class="home-posts-post-date">{{ post.date | date_to_string }}</span>
-    <span class="home-posts-post-arrow">&raquo;</span>
-    <a class="home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
-    ({{components}})
-    <span class="host">hosted by
-      <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
-    </span>
-  </div>{%- endif -%}
+  {% if posttime >= nowunix %}
+    <tr>
+      <div class="home-posts-post">
+        <td><span class="home-posts-post-date">{{ post.date | date_to_string }}</span></td>
+        <td><span class="home-posts-post-arrow">&raquo;</span></td>
+        <td><a class="home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
+        ({{components}})
+        <span class="host">hosted by
+        <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+        </span></td>
+      </div>
+    </tr>
+  {%- endif -%}
 {% endfor %}
+</table>
 
 We're always looking for interesting PRs to discuss in the review club and for
 volunteer hosts to lead the discussion:
@@ -71,6 +77,7 @@ volunteer hosts to lead the discussion:
 
 ## Recent Meetings
 
+<table>
 {% for post in site.posts limit: 5 %}
   {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
   {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
@@ -79,14 +86,19 @@ volunteer hosts to lead the discussion:
     <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %},{% endunless %}
   {%- endfor -%}
   {% endcapture %}
-  {% if posttime < nowunix %}<div class="home-posts-post">
-    <span class="home-posts-post-date">{{ post.date | date_to_string }}</span>
-    <span class="home-posts-post-arrow">&raquo;</span>
-    <a class="home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
-    ({{components}})
-    <span class="host">hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a></span>
-  </div>{%- endif -%}
+  {% if posttime < nowunix %}
+    <tr>
+      <div class="home-posts-post">
+        <td><span class="home-posts-post-date">{{ post.date | date_to_string }}</span></td>
+        <td><span class="home-posts-post-arrow">&raquo;</span></td>
+        <td><a class="home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
+        ({{components}})
+        <span class="host">hosted by <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a></span></td>
+      </div>
+    </tr>
+  {%- endif -%}
 {% endfor %}
+</table>
 
 See all [meetings](/meetings/).
 

--- a/meetings-components.html
+++ b/meetings-components.html
@@ -5,51 +5,51 @@ permalink: /meetings-components/
 ---
 
 {% capture raw_components %}
-{%- for meeting in site.posts -%}
-  {%- if meeting.layout == 'pr' -%}
-    {%- if meeting.components == empty -%}
-      {% include ERROR_92_MISSING_TOPIC_CATEGORY %}
+  {%- for meeting in site.posts -%}
+    {%- if meeting.layout == 'pr' -%}
+      {%- if meeting.components == empty -%}
+        {% include ERROR_92_MISSING_TOPIC_CATEGORY %}
+      {%- endif -%}
+      {%- for component in meeting.components -%}
+        {{component}}|
+      {%- endfor -%}
     {%- endif -%}
-    {%- for component in meeting.components -%}
-      {{component}}|
-    {%- endfor -%}
-  {%- endif -%}
-{%- endfor -%}
+  {%- endfor -%}
 {% endcapture %}
+
 {% assign components = raw_components | split: "|" | sort_natural | uniq %}
 
 <div class="Home">
-  <h2 class="Home-posts-title">
-    Meetings
-  </h2>
-  <p>
-    {% include linkers/meetings-pages.md %}
-  </p>
+  <h2 class="Home-posts-title">Meetings</h2>
+  <p>{% include linkers/meetings-pages.md %}</p>
 
-{% for component in components %}
-  <div id="{{component}}">
-    <h3 class="month">{{component}}</h3>
-    <table style="padding-left: 1.5em">
-      {% for post in site.posts %}
-        {% if post.components contains component %}
-        <div class="Home-posts-post"><tr>
-          <td><span class="Home-posts-post-date">
-            {{ post.date | date_to_string }}
-          </span></td>
-          <td><span class="Home-posts-post-arrow">
-            &raquo;
-          </span></td>
-          <td>
-            <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
-            <span class="host">
-              hosted by
-              <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
-            </span>
-          </td>
-        </tr></div>
-        {%- endif -%}
-      {% endfor %}
-    </table>
-  </div>
-{% endfor %}
+  {% for component in components %}
+    <div id="{{component}}">
+      <h3 class="month">{{component}}</h3>
+      <table style="padding-left: 1.5em">
+        {% for post in site.posts %}
+          {% if post.components contains component %}
+            <div class="Home-posts-post">
+              <tr>
+                <td class="Home-posts-post-date">
+                  {{ post.date | date_to_string }}
+                </td>
+                <td class="Home-posts-post-arrow">
+                  &raquo;
+                </td>
+                <td>
+                  <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
+                  <span class="host">
+                    hosted by
+                    <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+                  </span>
+                </td>
+              </tr>
+            </div>
+          {%- endif -%}
+        {% endfor %}
+      </table>
+    </div>
+  {% endfor %}
 </div>
+<br>

--- a/meetings-components.html
+++ b/meetings-components.html
@@ -28,24 +28,28 @@ permalink: /meetings-components/
 
 {% for component in components %}
   <div id="{{component}}">
-    <h3>
-      {{component}}
-    </h3>
-    <ul>
+    <h3 class="month">{{component}}</h3>
+    <table style="padding-left: 1.5em">
       {% for post in site.posts %}
-      {% if post.components contains component %}
-      <li>
-        <div class="Home-posts-post">
-          <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
-          <span class="host">
-            hosted by
-            <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
-          </span>
-        </div>
-      </li>
-      {%- endif -%}
+        {% if post.components contains component %}
+        <div class="Home-posts-post"><tr>
+          <td><span class="Home-posts-post-date">
+            {{ post.date | date_to_string }}
+          </span></td>
+          <td><span class="Home-posts-post-arrow">
+            &raquo;
+          </span></td>
+          <td>
+            <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
+            <span class="host">
+              hosted by
+              <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+            </span>
+          </td>
+        </tr></div>
+        {%- endif -%}
       {% endfor %}
-    </ul>
+    </table>
   </div>
 {% endfor %}
 </div>

--- a/meetings-hosts.html
+++ b/meetings-hosts.html
@@ -18,42 +18,39 @@ permalink: /meetings-hosts/
 {% assign hosts = raw_hosts | split: "|" | sort_natural | uniq %}
 
 <div class="Home">
-  <h2 class="Home-posts-title">
-    Meetings
-  </h2>
-  <p>
-    {% include linkers/meetings-pages.md %}
-  </p>
+  <h2 class="Home-posts-title">Meetings</h2>
+  <p>{% include linkers/meetings-pages.md %}</p>
 
-{% for host in hosts %}
-  <div id="{{host}}">
-    <h3 class="month">
-      {{host}}
-      <a href="https://github.com/{{host}}"><i class="fa fa-github"></i></a>
-    </h3>
-    <table style="padding-left: 1.5em">
-    {% for post in site.posts %}
-      {% capture components %}
-        {%- for comp in post.components -%}
-          <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
-        {%- endfor -%}
-      {% endcapture %}
-      {% if post.host == host %}
-      <tr><div class="Home-posts-post">
-        <td><span class="Home-posts-post-date">
-          {{ post.date | date_to_string }}
-        </span></td>
-        <td><span class="Home-posts-post-arrow">
-          &raquo;
-        </span></td>
-        <td>
-          <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
-          ({{components}})
-        </td>
-      </div><tr>
-      {%- endif -%}
-    {% endfor %}
-    </table>
-  </div>
-{% endfor %}
+  {% for host in hosts %}
+    <div id="{{host}}">
+      <h3 class="month">
+        {{host}}
+        <a href="https://github.com/{{host}}"><i class="fa fa-github"></i></a>
+      </h3>
+      <table style="padding-left: 1.5em">
+        {% for post in site.posts %}
+          {% capture components %}
+            {%- for comp in post.components -%}
+              <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+            {%- endfor -%}
+          {% endcapture %}
+          {% if post.host == host %}
+            <tr class="Home-posts-post">
+              <td class="Home-posts-post-date">
+                {{ post.date | date_to_string }}
+              </td>
+              <td class="Home-posts-post-arrow">
+                &raquo;
+              </td>
+              <td>
+                <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
+                ({{components}})
+              </td>
+            </tr>
+          {%- endif -%}
+        {% endfor %}
+      </table>
+    </div>
+  {% endfor %}
 </div>
+<br>

--- a/meetings-hosts.html
+++ b/meetings-hosts.html
@@ -27,11 +27,11 @@ permalink: /meetings-hosts/
 
 {% for host in hosts %}
   <div id="{{host}}">
-    <h3>
+    <h3 class="month">
       {{host}}
       <a href="https://github.com/{{host}}"><i class="fa fa-github"></i></a>
     </h3>
-    <ul>
+    <table style="padding-left: 1.5em">
     {% for post in site.posts %}
       {% capture components %}
         {%- for comp in post.components -%}
@@ -39,17 +39,21 @@ permalink: /meetings-hosts/
         {%- endfor -%}
       {% endcapture %}
       {% if post.host == host %}
-      <li>
-        <div class="Home-posts-post">
-          <a class="Home-posts-post-title" href="{{ post.url }}">
-            #{{ post.pr }} {{ post.title }}
-          </a>
+      <tr><div class="Home-posts-post">
+        <td><span class="Home-posts-post-date">
+          {{ post.date | date_to_string }}
+        </span></td>
+        <td><span class="Home-posts-post-arrow">
+          &raquo;
+        </span></td>
+        <td>
+          <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
           ({{components}})
-        </div>
-      </li>
+        </td>
+      </div><tr>
       {%- endif -%}
     {% endfor %}
-    </ul>
+    </table>
   </div>
 {% endfor %}
 </div>

--- a/meetings.html
+++ b/meetings.html
@@ -5,44 +5,45 @@ permalink: /meetings/
 ---
 
 <div class="Home">
+  <h2 class="Home-posts-title">Meetings</h2>
+  <p>{% include linkers/meetings-pages.md %}</p>
 
-<h2 class="Home-posts-title"> Meetings </h2>
+  {% for post in site.posts %}
+    {% capture components %}
+      {%- for comp in post.components -%}
+        <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
+      {%- endfor -%}
+    {% endcapture %}
 
-<p>{% include linkers/meetings-pages.md %}</p>
+    {% capture month_year %}{{ post.date | date: "%b %Y" }}{% endcapture %}
 
-{% for post in site.posts %}
-  {% capture components %}
-    {%- for comp in post.components -%}
-      <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
-    {%- endfor -%}
-  {% endcapture %}
+    {% if month_year != lastmy %}
+      {% if lastmy != nil %}</table></div>{% endif %}
+      <div id="{{ post.date | date: "%b%Y" }}">
+        <h3 class="month">{{ month_year }}</h3>
+        <table style="padding-left: 1.5em;">
+    {% endif %}
 
-  {% capture month_year %}{{ post.date | date: "%b %Y" }}{% endcapture %} 
-  {% if month_year != lastmy %}
-    {% if lastmy != nil %}</table></div>{% endif %}
-    <div id="{{ post.date | date: "%b%Y" }}">
-    <h3 class="month">{{ month_year }}</h3>
-    <table style="padding-left: 1.5em">
-  {% endif %}
-  {% assign lastmy = month_year %}
+    {% assign lastmy = month_year %}
 
-  <tr><div class="Home-posts-post">
-    <td><span class="Home-posts-post-date">
-      {{ post.date | date_to_string }}
-    </span></td>
-    <td><span class="Home-posts-post-arrow">
-      &raquo;
-    </span></td>
-    <td>
-      <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
-      ({{components}})
-      <span class="host">
-        hosted by
-        <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
-      </span>
-    </td>
-  </div></tr>
-{% endfor %}
-</table>
+    <tr class="Home-posts-post">
+      <td class="Home-posts-post-date">
+        {{ post.date | date_to_string }}
+      </td>
+      <td class="Home-posts-post-arrow">
+        &raquo;
+      </td>
+      <td>
+        <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
+        ({{components}})
+        <span class="host">
+          hosted by
+          <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+        </span>
+      </td>
+    </tr>
+  {% endfor %}
+  </table>
+  </div>
 </div>
-</div>
+<br>

--- a/meetings.html
+++ b/meetings.html
@@ -5,12 +5,10 @@ permalink: /meetings/
 ---
 
 <div class="Home">
-  <h2 class="Home-posts-title">
-    Meetings
-  </h2>
-  <p>
-    {% include linkers/meetings-pages.md %}
-  </p>
+
+<h2 class="Home-posts-title"> Meetings </h2>
+
+<p>{% include linkers/meetings-pages.md %}</p>
 
 {% for post in site.posts %}
   {% capture components %}
@@ -19,19 +17,32 @@ permalink: /meetings/
     {%- endfor -%}
   {% endcapture %}
 
-  <div class="Home-posts-post">
-    <span class="Home-posts-post-date">
+  {% capture month_year %}{{ post.date | date: "%b %Y" }}{% endcapture %} 
+  {% if month_year != lastmy %}
+    {% if lastmy != nil %}</table></div>{% endif %}
+    <div id="{{ post.date | date: "%b%Y" }}">
+    <h3 class="month">{{ month_year }}</h3>
+    <table style="padding-left: 1.5em">
+  {% endif %}
+  {% assign lastmy = month_year %}
+
+  <tr><div class="Home-posts-post">
+    <td><span class="Home-posts-post-date">
       {{ post.date | date_to_string }}
-    </span>
-    <span class="Home-posts-post-arrow">
+    </span></td>
+    <td><span class="Home-posts-post-arrow">
       &raquo;
-    </span>
-    <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
-    ({{components}})
-    <span class="host">
-      hosted by
-      <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
-    </span>
-  </div>
+    </span></td>
+    <td>
+      <a class="Home-posts-post-title" href="{{ post.url }}">#{{ post.pr }} {{ post.title }}</a>
+      ({{components}})
+      <span class="host">
+        hosted by
+        <a class="host" href="/meetings-hosts/#{{post.host}}">{{ post.host }}</a>
+      </span>
+    </td>
+  </div></tr>
 {% endfor %}
+</table>
+</div>
 </div>


### PR DESCRIPTION
These commits are suggestions that build on #79 with the following steps:

- Noticed that the new date table columns were being wrapped in narrow browser window sizes
- Added CSS to fix that, but it was not being applied
- This was due to extraneous HTML span tags inside the table markup. I removed those.
- To make sure I wasn't breaking anything, I began indenting the HTML more clearly.
- The indentation revealed a few issues like missing closing tags, so I fixed those.
- Added a `<br>` tag to the bottom of each meeting page to add a line of space so the text at the bottom of the page doesn't hug the window border as tightly; though it should probably be done with CSS instead
- The dates are no longer wrapped (yay) but that adds some padding to the left of the ">" separator, so I added CSS to add a bit of right padding to balance that out
- I'm not a front end expert and am unsure if pixels (`px`) are the best units to use for wide compatibility, noticing that the other CSS mostly uses `em` units, but they offer fine-grained control

Apologies for the difficult-to-read diff in the meeting pages.