### PR TITLE
layout: include time and place on PR page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,10 @@ sass:
   sass_dir: assets/css
   style: :compressed
 
-# Customise atom feed settings (this is where Jekyll-Feed gets configuration information)
-title:		           "Bitcoin Core PR Review Club"
-description:	       "A weekly review club for Bitcoin Core PRs"
-author:              "John Newbery"
+# Site settings
+title:             "Bitcoin Core PR Review Club"
+description:       "A weekly review club for Bitcoin Core PRs"
+author:            "Bitcoin Core PR Review Club contributors"
+meeting_time:      "18:00 UTC"
+meeting_day:       "Wednesday"
+meeting_location:  "#bitcoin-core-pr-reviews IRC channel on <a href=\"https://webchat.freenode.net\">freenode</a>"

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -14,6 +14,13 @@ layout: default
     <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">
       {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
       {{ page.date | date: date_format }}
+      {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
+      {% capture posttime %}{{page.date | date: '%s'}}{% endcapture %}
+      {% if posttime >= nowunix %}
+        {{ site.meeting_time }}
+        at
+        {{ site.meeting_location }}
+      {%- endif -%}
     </time>
     <p style="font-weight:bold">
       <a href="https://github.com/bitcoin/bitcoin/pull/{{ page.pr }}">

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: home
 ### A weekly review club for Bitcoin Core PRs
 
 <span class="question">What is this?</span> &nbsp;A weekly club for reviewing
-Bitcoin Core PRs at **18:00 UTC on Wednesdays** on IRC.
+Bitcoin Core PRs at **{{ site.meeting_time }} on {{ site.meeting_day }}s** on IRC.
 
 <span class="question">What's it for?</span> &nbsp;To help newer contributors
 learn about the Bitcoin Core review process. The review club is *not* primarily
@@ -31,8 +31,7 @@ on GitHub.
    and build the PR branch, and run all tests.
 2. Review the code changes and read the comments on the PR.
 3. Make a note of any questions you want to ask.
-4. Join the [freenode](https://webchat.freenode.net/)`#bitcoin-core-pr-reviews`
-   IRC channel at **18:00 UTC on Wednesday**.
+4. Join the {{ site.meeting_location }} at **{{ site.meeting_time }} on {{ site.meeting_day }}**.
 
 <span class="question">Who runs this?</span> &nbsp;Bitcoin Core contributor
 [jnewbery](https://github.com/jnewbery) started the review club and schedules


### PR DESCRIPTION
I sent this week's meeting link to some coworkers, they asked me how to join the meeting!
This PR adds the where & when to each meeting page:

#### Current

<img width="1017" alt="Screen Shot 2019-12-09 at 10 13 44 AM" src="https://user-images.githubusercontent.com/2084648/70461108-c3ae6d80-1a6c-11ea-9dc6-bb76802ac7c2.png">

#### Updated

<img width="1018" alt="Screen Shot 2019-12-09 at 10 13 38 AM" src="https://user-images.githubusercontent.com/2084648/70461119-ca3ce500-1a6c-11ea-844a-866c7c471d70.png">
