### PR TITLE
Add n17639 and update rake posts:new task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -147,7 +147,7 @@ def create_post_file!(filename, response, date, host)
     line.puts '---'
     line.puts 'layout: pr'
     line.puts "date: #{date}"
-    line.puts "title: \"#{response['title']}\""
+    line.puts "title: #{parse_title(response['title'])}"
     line.puts "pr: #{response['number']}"
     line.puts "authors: [#{response.dig('user', 'login')}]"
     line.puts "components: #{parse_components(response['labels'])}"
@@ -156,6 +156,10 @@ def create_post_file!(filename, response, date, host)
     line.puts "## Notes\n\n"
     line.puts "## Questions\n"
   end
+end
+
+def parse_title(title)
+  "\"#{title.gsub(/"/,  '')}\""
 end
 
 def parse_components(labels)

--- a/_posts/2019-12-11-#16702.md
+++ b/_posts/2019-12-11-#16702.md
@@ -62,7 +62,7 @@ from just 2 large ASNs.
 - The idea is that allowing nodes to connect to each globally unique ASN *only
 once* should increase the security of the Bitcoin network by diversifying
 connections. With this PR, instead of connecting to possibly as few as 2 ASNs,
-nodes would connect to a minimum of 8.
+nodes would connect to 8 different ASNs.
 
 - Diversifying network connections is motivated by the [Erebus
   Attack](/16702.html#erebus-attack). The word *Erebus* is ancient Greek for

--- a/_posts/2019-12-18-#17639.md
+++ b/_posts/2019-12-18-#17639.md
@@ -1,0 +1,13 @@
+---
+layout: pr
+date: 2019-12-18
+title: "Add make check-valgrind to run the unit tests under Valgrind"
+pr: 17639
+authors: [practicalswift]
+components: ["tests"]
+host: jonatack
+---
+
+## Notes
+
+## Questions


### PR DESCRIPTION
to handle PR titles containing double quotes, like for next week's PR 17639, without making Jekyll halt. I went with simply stripping the double quotes. Alternatively, we could convert the double quotes to single quotes. I didn't find it as aesthetic in this case, but it could be an option.

Also made a minor fixup in yesterday's meeting notes.
