### PR TITLE
Remove component from PR title in rake posts:new

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -161,8 +161,22 @@ def create_post_file!(filename, response, date, host)
 end
 
 def parse_title(title)
+  first, *rest = title.split # e.g. if title = "a b c", first = "a", rest = ["b", "c"]
+  first.downcase! # mutate first word to lowercase in place
+  prefix = first.gsub(/[:\[\]]/, '') # prefix is first word stripped of :[] chars
+
+  # If prefix is different from first word and is a component, set title to the rest.
+  title = rest.join(' ') if first != prefix && is_a_component?(prefix)
+
   # Return title enclosed in double quotes after removing any double quotes.
   "\"#{title.gsub(/"/,  '')}\""
+end
+
+def is_a_component?(prefix)
+  # Boolean indicating whether `prefix` (without any final "s") is a component.
+  # Iterates through the COMPONENTS array and exits with true at the first
+  # instance where `prefix` is a substring of the component; otherwise false.
+  COMPONENTS.any? { |component| component.include?(prefix.chomp('s')) }
 end
 
 def parse_components(labels)

--- a/Rakefile
+++ b/Rakefile
@@ -145,14 +145,22 @@ rescue *HTTP_ERRORS => e
 end
 
 def create_post_file!(filename, response, date, host)
+  title = parse_title(response['title'])
+  components = parse_valid_components(response['labels'])
+
+  puts "GitHub PR title:  \"#{response['title']}\""
+  puts "Parsed PR title:  #{title}"
+  puts "GitHub PR labels: \"#{parse_components(response['labels']).join(', ')}\""
+  puts "Parsed PR labels: \"#{components.join(', ')}\""
+
   File.open(filename, 'w') do |line|
     line.puts '---'
     line.puts 'layout: pr'
     line.puts "date: #{date}"
-    line.puts "title: #{parse_title(response['title'])}"
+    line.puts "title: #{title}"
     line.puts "pr: #{response['number']}"
     line.puts "authors: [#{response.dig('user', 'login')}]"
-    line.puts "components: #{parse_components(response['labels'])}"
+    line.puts "components: #{components}"
     line.puts "host: #{host}"
     line.puts "---\n\n"
     line.puts "## Notes\n\n"
@@ -180,5 +188,9 @@ def is_a_component?(prefix)
 end
 
 def parse_components(labels)
-  (labels.map { |label| label['name'].downcase }) & COMPONENTS
+  (labels.map { |label| label['name'].downcase })
+end
+
+def parse_valid_components(labels)
+  parse_components(labels) & COMPONENTS
 end

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,8 @@ DESIRED_COMPONENTS = [
   'Wallet',
 ].freeze
 
+COMPONENTS = DESIRED_COMPONENTS.map(&:downcase).freeze
+
 GITHUB_API_URL = 'https://api.github.com/repos/bitcoin/bitcoin/pulls'
 HTTP_SUCCESS  = '200'
 HTTP_NOTFOUND = '404'
@@ -159,9 +161,10 @@ def create_post_file!(filename, response, date, host)
 end
 
 def parse_title(title)
+  # Return title enclosed in double quotes after removing any double quotes.
   "\"#{title.gsub(/"/,  '')}\""
 end
 
 def parse_components(labels)
-  (labels.map { |label| label['name'].downcase }) & DESIRED_COMPONENTS.map(&:downcase)
+  (labels.map { |label| label['name'].downcase }) & COMPONENTS
 end


### PR DESCRIPTION
A few force pushes to simplify the change and add comments.

Added logging to see the results while running `rake posts:new`.

Handle some edge cases seen while testing.