### PR TITLE
Add status variable to PR page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,16 @@ Some tips for hosting a great review club meeting:
 - Have fun, and pat yourself on the back for making Bitcoin protocol development
   stronger and more decentralized 🚀
 
+### After the Meeting
+
+One of the review club maintainers will:
+
+- Copy the meeting log to the `## Meeting Log` section of the meeting post.
+  Meeting logs should be copied exactly, but an `## Erratum` section can be
+  added to correct factual errors.
+
+- Change the `status` of the meeting post to `past`.
+
 ## Making a New Post
 
 To make a new post, run the following Ruby make command from root or the

--- a/Rakefile
+++ b/Rakefile
@@ -167,6 +167,7 @@ def create_post_file!(filename, response, date, host)
     line.puts "authors: [#{response.dig('user', 'login')}]"
     line.puts "components: #{components}"
     line.puts "host: #{host}"
+    line.puts "status: upcoming"
     line.puts "---\n\n"
     line.puts "## Notes\n\n"
     line.puts "## Questions\n"

--- a/_layouts/pr.html
+++ b/_layouts/pr.html
@@ -14,9 +14,7 @@ layout: default
     <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">
       {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
       {{ page.date | date: date_format }}
-      {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
-      {% capture posttime %}{{page.date | date: '%s'}}{% endcapture %}
-      {% if posttime >= nowunix %}
+      {% if page.status == "upcoming" %}
         {{ site.meeting_time }}
         at
         {{ site.meeting_location }}

--- a/_posts/2019-05-01-#15557.md
+++ b/_posts/2019-05-01-#15557.md
@@ -4,6 +4,7 @@ title: "Enhance bumpfee to include inputs when targeting a feerate"
 components: [wallet]
 pr: 15557
 host: jnewbery
+status: past
 ---
 
 ## Meeting Log

--- a/_posts/2019-05-08-#10823.md
+++ b/_posts/2019-05-08-#10823.md
@@ -4,6 +4,7 @@ title: "Allow all mempool txs to be replaced after a configurable timeout (defau
 components: [mempool, policy]
 pr: 10823
 host: jnewbery
+status: past
 ---
 
 ## Meeting Log

--- a/_posts/2019-05-15-#15834.md
+++ b/_posts/2019-05-15-#15834.md
@@ -4,6 +4,7 @@ title: "Fix NOTFOUND bug and expire getdata requests for transactions"
 components: [net processing]
 pr: 15834
 host: jnewbery
+status: past
 ---
 
 ## Meeting Log

--- a/_posts/2019-05-22-#15450.md
+++ b/_posts/2019-05-22-#15450.md
@@ -4,6 +4,7 @@ title: "Create wallet menu option"
 components: [gui]
 pr: 15450
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-05-29-#15741.md
+++ b/_posts/2019-05-29-#15741.md
@@ -4,6 +4,7 @@ title: "Batch write imported stuff in importmulti"
 components: [wallet]
 pr: 15741
 host: ariard
+status: past
 ---
 
 ## Meeting Log

--- a/_posts/2019-05-29-#15741.md
+++ b/_posts/2019-05-29-#15741.md
@@ -6,7 +6,7 @@ pr: 15741
 host: ariard
 ---
 
-## Meeting log
+## Meeting Log
 
 ```
 10:58 < jnewbery> Reminder that this week's meeting starts in two hours. We'll be looking at #15741

--- a/_posts/2019-06-05-#16060.md
+++ b/_posts/2019-06-05-#16060.md
@@ -4,6 +4,7 @@ title: "Bury bip9 deployments"
 components: [consensus]
 pr: 16060
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-06-12-#15996.md
+++ b/_posts/2019-06-12-#15996.md
@@ -4,6 +4,7 @@ title: "Deprecate totalfee argument in `bumpfee`"
 components: [rpc]
 pr: 15996
 host: jnewbery
+status: past
 ---
 
 ## Meeting Log

--- a/_posts/2019-06-19-#15481.md
+++ b/_posts/2019-06-19-#15481.md
@@ -4,6 +4,7 @@ title: "Restrict timestamp when mining a diff-adjustment block to prev-600"
 components: [mining]
 pr: 15481
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-06-26-#15681.md
+++ b/_posts/2019-06-26-#15681.md
@@ -4,6 +4,7 @@ title: "Allow one extra single-ancestor transaction per package"
 components: [mempool]
 pr: 15681
 host: harding
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-07-03-#15443.md
+++ b/_posts/2019-07-03-#15443.md
@@ -4,6 +4,7 @@ title: "Add getdescriptorinfo functional test"
 components: [tests]
 pr: 15443
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-07-10-#16244.md
+++ b/_posts/2019-07-10-#16244.md
@@ -4,6 +4,7 @@ title: "Move wallet creation out of the createwallet rpc into its own function"
 components: [wallet]
 pr: 16244
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-07-17-#15169.md
+++ b/_posts/2019-07-17-#15169.md
@@ -4,6 +4,7 @@ title: "Parallelize CheckInputs() in AcceptToMemoryPool()"
 components: [mempool]
 pr: 15169
 host: jachiang
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-07-24-#15713.md
+++ b/_posts/2019-07-24-#15713.md
@@ -4,6 +4,7 @@ title: "Replace chain relayTransactions/submitMemoryPool by higher method"
 components: [wallet]
 pr: 15713
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-07-31-#15505.md
+++ b/_posts/2019-07-31-#15505.md
@@ -4,6 +4,7 @@ title: "Request NOTFOUND transactions immediately from other outbound peers, whe
 components: [p2p]
 pr: 15505
 host: mzumsande
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-07-31-#15505.md
+++ b/_posts/2019-07-31-#15505.md
@@ -20,7 +20,7 @@ host: mzumsande
 - Why are only outbound peers considered for requesting transactions after receiving `NOTFOUND`?
 - What kind of options exist in the functional testing framework for P2P functionality? Why is it so hard to test PRs like this one with the existing framework?
 
-## Meeting log
+## Meeting Log
 
 ```
 13:00 < jnewbery_> hi

--- a/_posts/2019-08-07-#16345.md
+++ b/_posts/2019-08-07-#16345.md
@@ -4,6 +4,7 @@ title: "Add getblockbyheight method / support @height in place of blockhash for 
 components: [rpc]
 pr: 16345
 host: jnewbery
+status: past
 ---
 
 - [https://github.com/bitcoin/bitcoin/pull/16345](https://github.com/bitcoin/bitcoin/pull/16345)

--- a/_posts/2019-08-14-#16115.md
+++ b/_posts/2019-08-14-#16115.md
@@ -4,6 +4,7 @@ title: "On bitcoind startup, write config args to debug.log"
 components: [config]
 pr: 16115
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-08-21-#15931.md
+++ b/_posts/2019-08-21-#15931.md
@@ -4,6 +4,7 @@ title: "Remove GetDepthInMainChain dependency on locked chain interface"
 components: [wallet]
 pr: 15931
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-08-28-#15759.md
+++ b/_posts/2019-08-28-#15759.md
@@ -4,6 +4,7 @@ title: "Add 2 outbound blocks-only connections"
 components: [p2p]
 pr: 15759
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-09-04-#16512.md
+++ b/_posts/2019-09-04-#16512.md
@@ -4,6 +4,7 @@ title: "Shuffle inputs and outputs after joining psbts"
 components: [rpc]
 pr: 16512
 host: jnewbery
+status: past
 ---
 
 Today's PR is very small and should be a quick review. We'll spend half the

--- a/_posts/2019-09-11-#16688.md
+++ b/_posts/2019-09-11-#16688.md
@@ -4,6 +4,7 @@ title: "Add validation interface logging"
 components: [logging]
 pr: 16688
 host: jkczyz
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-09-18-#15204.md
+++ b/_posts/2019-09-18-#15204.md
@@ -4,6 +4,7 @@ title: "Add Open External Wallet action"
 components: [gui]
 pr: 15204
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-09-25-#16202.md
+++ b/_posts/2019-09-25-#16202.md
@@ -54,7 +54,7 @@ host: jonatack
 
 - Any other comments, feedback, or questions?
 
-## Meeting log
+## Meeting Log
 
 ```
 19:00 <jonatack> Hi all! Welcome to this week's episode of the Bitcoin Core PR Review club.

--- a/_posts/2019-09-25-#16202.md
+++ b/_posts/2019-09-25-#16202.md
@@ -4,6 +4,7 @@ title: "Refactor network message deserialization"
 components: [net processing]
 pr: 16202
 host: jonatack
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-10-02-#16401.md
+++ b/_posts/2019-10-02-#16401.md
@@ -4,6 +4,7 @@ title: "Package relay"
 components: [p2p]
 pr: 16401
 host: jonatack
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-10-02-#16401.md
+++ b/_posts/2019-10-02-#16401.md
@@ -76,7 +76,7 @@ A related PR opened recently by Anthony Towns (ajtowns) that you may wish to
 review: [PR #16851](https://github.com/bitcoin/bitcoin/pull/16851) "Continue
 relaying transactions after they expire from mapRelay."
 
-## Meeting log
+## Meeting Log
 
 ```
 19:00 <jonatack> Hi all! Welcome to this week's episode of the Bitcoin Core PR Review club.

--- a/_posts/2019-10-09-#16939.md
+++ b/_posts/2019-10-09-#16939.md
@@ -5,6 +5,7 @@ pr: 16939
 components: [p2p]
 authors: [ajtowns]
 host: jnewbery
+status: past
 ---
 
 We will discuss both [PR 15558](https://github.com/bitcoin/bitcoin/pull/15558)

--- a/_posts/2019-10-16-#16279.md
+++ b/_posts/2019-10-16-#16279.md
@@ -6,6 +6,7 @@ pr: 16279
 authors: [TheBlueMatt]
 components: ["validation"]
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-10-23-#15934.md
+++ b/_posts/2019-10-23-#15934.md
@@ -6,6 +6,7 @@ pr: 15934
 authors: [ryanofsky]
 components: ["config"]
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-10-30-#15921.md
+++ b/_posts/2019-10-30-#15921.md
@@ -6,6 +6,7 @@ pr: 15921
 authors: [jnewbery]
 components: ["validation"]
 host: jnewbery
+status: past
 ---
 
 **Happy half-birthday to PR review club 🎉**

--- a/_posts/2019-11-06-#15845.md
+++ b/_posts/2019-11-06-#15845.md
@@ -6,6 +6,7 @@ pr: 15845
 authors: [MarcoFalke]
 components: ["wallet"]
 host: jnewbery
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-11-13-#17303.md
+++ b/_posts/2019-11-13-#17303.md
@@ -6,6 +6,7 @@ pr: 17303
 authors: [MarcoFalke]
 components: ["p2p"]
 host: MarcoFalke
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-11-20-#16442.md
+++ b/_posts/2019-11-20-#16442.md
@@ -6,6 +6,7 @@ pr: 16442
 authors: [jimpo]
 components: ["p2p"]
 host: pinheadmz
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-11-27-#16698.md
+++ b/_posts/2019-11-27-#16698.md
@@ -6,6 +6,7 @@ pr: 16698
 authors: [amitiuttarwar]
 components: ["mempool", "p2p", "wallet"]
 host: amitiuttarwar
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-12-04-#16426.md
+++ b/_posts/2019-12-04-#16426.md
@@ -6,6 +6,7 @@ pr: 16426
 authors: [ariard]
 components: ["wallet"]
 host: ariard
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-12-11-#16702.md
+++ b/_posts/2019-12-11-#16702.md
@@ -6,6 +6,7 @@ pr: 16702
 authors: [naumenkogs]
 components: ["p2p"]
 host: jonatack
+status: past
 ---
 
 ## Notes

--- a/_posts/2019-12-18-#17639.md
+++ b/_posts/2019-12-18-#17639.md
@@ -6,6 +6,7 @@ pr: 17639
 authors: [practicalswift]
 components: ["tests"]
 host: jonatack
+status: past
 ---
 
 ## Notes

--- a/_posts/2020-01-08-#14053.md
+++ b/_posts/2020-01-08-#14053.md
@@ -6,6 +6,7 @@ pr: 14053
 authors: [marcinja]
 components: ["utxo db and indexes"]
 host: jnewbery
+status: past
 ---
 
 _The PR branch HEAD was [ec5fbd0b](https://github.com/bitcoin-core-review-club/bitcoin/tree/pr14053) at the time of this review club meeting._

--- a/_posts/2020-01-15-#17860.md
+++ b/_posts/2020-01-15-#17860.md
@@ -6,6 +6,7 @@ pr: 17860
 authors: [MarcoFalke]
 components: ["tests"]
 host: MarcoFalke
+status: past
 ---
 
 _The PR branch HEAD was [8b868f17](https://github.com/bitcoin-core-review-club/bitcoin/tree/pr17860) at the time of this review club meeting._

--- a/index.md
+++ b/index.md
@@ -42,14 +42,12 @@ Core contributors. See some of our [previous hosts](/meetings-hosts/).
 
 <table>
 {% for post in site.posts reversed %}
-  {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
-  {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
   {% capture components %}
   {%- for comp in post.components -%}
     <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %}, {% endunless %}
   {%- endfor -%}
   {% endcapture %}
-  {% if posttime >= nowunix %}
+  {% if post.status == "upcoming" %}
     <tr>
       <div class="home-posts-post">
         <td class="Home-posts-post-date">{{ post.date | date_to_string }}</td>
@@ -78,14 +76,12 @@ volunteer hosts to lead the discussion:
 
 <table>
 {% for post in site.posts limit: 5 %}
-  {% capture nowunix %}{{'now' | date: "%s"}}{% endcapture %}
-  {% capture posttime %}{{post.date | date: '%s'}}{% endcapture %}
   {% capture components %}
   {%- for comp in post.components -%}
     <a href="/meetings-components/#{{comp}}">{{comp}}</a>{% unless forloop.last %},{% endunless %}
   {%- endfor -%}
   {% endcapture %}
-  {% if posttime < nowunix %}
+  {% if post.status == "past" %}
     <tr>
       <div class="home-posts-post">
         <td class="Home-posts-post-date">{{ post.date | date_to_string }}</td>


### PR DESCRIPTION
Add a status {"upcoming", "past"} variable to the meeting page and remove date/time-matching code.

This will allow us to make changes to the page on the day of the meeting without it being moved to the "recent meetings" section.