### PR TITLE
Update new post file and maintainer info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,18 +100,55 @@ Some tips for hosting a great review club meeting:
 
 One of the review club maintainers will:
 
-- Copy the meeting log to the `## Meeting Log` section of the meeting post.
-  Meeting logs should be copied exactly, but an `## Erratum` section can be
-  added to correct factual errors.
+- Uncomment the `## Meeting Log` markup in the meeting post and copy-paste the
+  meeting log into it.  Meeting logs should be copied exactly, but an `##
+  Erratum` section can be added to correct factual errors.
 
-- Change the `status` of the meeting post to `past`.
+- Change the `status` of the meeting post from `upcoming` to `past`.
+  ```diff
+  -status: upcoming
+  +status: past
+  ```
 
-- (optionally) push a tag of the branch at the time of the meeting to the
-  [PR Review Club Bitcoin repo](https://github.com/bitcoin-core-review-club/bitcoin)
-  and add a `commit` variable to the PR page to add a link to the branch. This
-  is so if the PR branch changes drastically after the review club meeting,
-  people reading the notes and log later can see the branch as it was at the time
-  of the meeting.
+- Add the first 7 characters of the PR commit hash at HEAD to the meeting post.
+  This adds a link to the tagged branch that you'll make in the next step.
+  ```diff
+  -commit:
+  +commit: eebaca7
+  ```
+
+- Push a tag of the branch at the time of the meeting to the [PR Review Club
+  Bitcoin repo](https://github.com/bitcoin-core-review-club/bitcoin). This is so
+  if the PR branch changes after the review club meeting, people reading the
+  notes and log later can see the branch as it was at the time of the meeting.
+
+  - Run these steps from the root of your local bitcoin repo.
+    ```
+    cd bitcoin
+    ```
+
+  - The first time you do this, you'll need to add the [review club bitcoin
+    repo](https://github.com/bitcoin-core-review-club/bitcoin) (here we name it
+    `review-club`) to your git remotes, either via HTTPS...
+    ```
+    git remote add review-club https://github.com/bitcoin-core-review-club/bitcoin.git
+    ```
+    ...or SSH.
+    ```
+    git remote add review-club git@github.com:bitcoin-core-review-club/bitcoin.git
+    ```
+
+  - Create a tag for the review PR (using the same PR commit hash as in the
+    preceding step).
+    ```
+    git checkout <PR commit hash>    # e.g. git checkout eebaca7
+    git tag pr<number>               # e.g. git tag pr17487
+    ```
+
+  - Push the new tag.
+    ```
+    git push review-club pr<number>  # e.g. git push review-club pr17487
+    ```
 
 ## Making a New Post
 

--- a/Rakefile
+++ b/Rakefile
@@ -168,9 +168,16 @@ def create_post_file!(filename, response, date, host)
     line.puts "components: #{components}"
     line.puts "host: #{host}"
     line.puts "status: upcoming"
+    line.puts "commit:"
     line.puts "---\n\n"
     line.puts "## Notes\n\n"
     line.puts "## Questions\n"
+    line.puts "\n"
+    line.puts "<!-- TODO: uncomment and add meeting log"
+    line.puts "## Meeting Log\n"
+    line.puts "```\n"
+    line.puts "```\n"
+    line.puts "--->\n"
   end
 end
 

--- a/index.md
+++ b/index.md
@@ -115,7 +115,7 @@ See all [meetings](/meetings/).
 - Brush up on your C++. There are [many primers and reference manuals
   available](https://stackoverflow.com/questions/388242/the-definitive-c-book-guide-and-list).
 - There are some excellent blog posts on how to start contributing to Bitcoin Core:
-    - [A Gentle Introductio to Bitcoin Core Development (Jimmy Song)](https://bitcointechtalk.com/a-gentle-introduction-to-bitcoin-core-development-fdc95eaee6b8)
+    - [A Gentle Introduction to Bitcoin Core Development (Jimmy Song)](https://bitcointechtalk.com/a-gentle-introduction-to-bitcoin-core-development-fdc95eaee6b8)
     - [Contributing to Bitcoin Core - a Personal Account (John Newbery)](https://bitcointechtalk.com/contributing-to-bitcoin-core-a-personal-account-35f3a594340b)
     - [Onboarding to Bitcoin Core (Amiti Uttarwar)](https://medium.com/@amitiu/onboarding-to-bitcoin-core-7c1a83b20365)
     - [How to Review Pull Requests in Bitcoin Core (Jon Atack)](https://jonatack.github.io/articles/how-to-review-pull-requests-in-bitcoin-core)


### PR DESCRIPTION
- Add `commit` field and meeting log section to the files generated by the `rake posts:new" task
- Propose steps for adding PR tags and commits in CONTRIBUTING.md
- Propose moving the maintainer info to the bottom of CONTRIBUTING.md

The updated version of CONTRIBUTING.md can be viewed here:
https://github.com/jonatack/bitcoin-core-review-club.github.io/blob/add-tag-commit-hash-info-to-CONTRIBUTING/CONTRIBUTING.md