### PR TITLE
Don't clean jekyll between previews

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 all: build
 
-preview:
+clean:
 	bundle exec jekyll clean
+
+preview:
 	bundle exec jekyll serve --future --drafts --unpublished --incremental
 
 build:


### PR DESCRIPTION
No need to clean jekyll when doing a `make preview`. Just run jekyll serve --incremental so we don't rebuild everything.

This brings build times down from ~8s to <0.5s.

`make build` still does a clean since it's not doing an incremental build so we might as well clean. Also add a `make clean` target.

Historic note: I copied our makefile from optech, and Dave copied that makefile from bitcoin.org, where he needed to use clean because some of their custom plugins didn't work well with incremental builds.