### PR TITLE
Convert auto_logs_markup global plugin to callable tag

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -175,6 +175,9 @@ def create_post_file!(filename, response, date, host)
     line.puts "\n"
     line.puts "<!-- TODO: uncomment and add meeting log"
     line.puts "## Meeting Log\n"
+    line.puts "\n"
+    line.puts "{% irc %}"
+    line.puts "{% endirc %}"
     line.puts "--->\n"
   end
 end

--- a/_plugins/auto_logs_markup.rb
+++ b/_plugins/auto_logs_markup.rb
@@ -2,60 +2,74 @@
 
 require 'uri'
 
-# URI schemes to accept for extraction.
-URI_SCHEMES = %w(http https).freeze
+module Jekyll
+  class IRCBlock < Liquid::Block
+    # Convert IRC meeting logs from plain text to HTML with functional links
+    # and log lines by enclosing them in {% irc %} and {% endirc %} tags.
 
-# Trailing chars (all punctuation except "/") to remove from URIs.
-TRAILING = /[^\/[:^punct:]]+$/
+    # URI schemes to accept for extraction.
+    URI_SCHEMES = %w(http https).freeze
 
-# Regex to select lines starting with "HH:MM " time.
-HH_MM = /^([0-1][0-9]|[2][0-3]):[0-5][0-9] .*/
+    # Trailing chars (all punctuation except "/") to remove from URIs.
+    TRAILING = /[^\/[:^punct:]]+$/
 
-# Regex to select IRC <nick>.
-IRC_NICK = /<.+?>/
+    # Regex to select lines starting with "HH:MM " time.
+    HH_MM = /^([0-1][0-9]|[2][0-3]):[0-5][0-9] .*/
 
-# Regex to select "<" and ">" chars.
-LT_GT = /[<>]/
+    # Regex to select IRC <nick>.
+    IRC_NICK = /<.+?>/
 
-# Maximum digits to display for log lines.
-LINE_DIGITS = 3
+    # Regex to select "<" and ">" chars.
+    LT_GT = /[<>]/
 
-# Length of timestamp string being used.
-TIME_SIZE = 'HH:MM'.size
-TIME_SIZE_PLUS_1 = TIME_SIZE + 1 # Micro-perf optimization
+    # Maximum digits to display for log lines.
+    LINE_DIGITS = 3
 
-NON_BREAKING_SPACE = '&nbsp;'
+    # Length of timestamp string being used.
+    TIME_SIZE = 'HH:MM'.size
+    TIME_SIZE_PLUS_1 = TIME_SIZE + 1 # Micro-perf optimization
 
-# Convert logs from plain text to HTML with line number links.
-#
-Jekyll::Hooks.register :documents, :pre_render do |post|
+    NON_BREAKING_SPACE = '&nbsp;'
 
-  # Loop through each line of the meeting logs.
-  post.content.gsub!(HH_MM).with_index(1) do |line, index|
-
-    # Separate the log line into useful parts.
-    lineno  = "#{NON_BREAKING_SPACE * (LINE_DIGITS - index.to_s.size)}#{index}"
-    time    = line[0..TIME_SIZE]
-    name    = IRC_NICK.match(line).to_s
-    nick    = name.gsub(LT_GT, '').strip
-    message = CGI.escapeHTML(line[TIME_SIZE_PLUS_1 + name.size..-1])
-
-    # Extract URIs from the message and convert them to HTML links.
-    URI.extract(message, schemes = URI_SCHEMES).each do |uri|
-      link = uri.sub(TRAILING, '') # Strip unwanted trailing punctuation
-      message.sub!(link, "<a href='#{link}' target='blank'>#{link}</a>")
+    def initialize(tag_name, text, tokens)
+      super
     end
 
-    # Return the log line as HTML markup.
-    "<table class='log-line' id='l-#{index}'>" \
-      "<tr class='log-row'>" \
-        "<td class='log-lineno'><a href='#l-#{index}'>#{lineno}</a></td>" \
-        "<td class='log-time'>#{time}</td>" \
-        "<td>" \
-          "<span class='log-nick'>&lt;#{nick}&gt;</span>" \
-          "<span class='log-msg'>#{message}</span>" \
-        "</td>" \
-      "</tr>" \
-    "</table>"
+    def render(context)
+      output = super
+
+      # Loop through each line of the meeting logs.
+      output.gsub!(HH_MM).with_index(1) do |line, index|
+
+        # Separate the log line into useful parts.
+        lineno  = "#{NON_BREAKING_SPACE * (LINE_DIGITS - index.to_s.size)}#{index}"
+        time    = line[0..TIME_SIZE]
+        name    = IRC_NICK.match(line).to_s
+        nick    = name.gsub(LT_GT, '').strip
+        message = CGI.escapeHTML(line[TIME_SIZE_PLUS_1 + name.size..-1])
+
+        # Extract URIs from the message and convert them to HTML links.
+        URI.extract(message, schemes = URI_SCHEMES).each do |uri|
+          link = uri.sub(TRAILING, '') # Strip unwanted trailing punctuation
+          message.sub!(link, "<a href='#{link}' target='blank'>#{link}</a>")
+        end
+
+        # Return the log line as HTML markup.
+        "<table class='log-line' id='l-#{index}'>" \
+          "<tr class='log-row'>" \
+            "<td class='log-lineno'><a href='#l-#{index}'>#{lineno}</a></td>" \
+            "<td class='log-time'>#{time}</td>" \
+            "<td>" \
+              "<span class='log-nick'>&lt;#{nick}&gt;</span>" \
+              "<span class='log-msg'>#{message}</span>" \
+            "</td>" \
+          "</tr>" \
+        "</table>"
+      end
+
+      output
+    end
   end
 end
+
+Liquid::Template.register_tag('irc', Jekyll::IRCBlock)

--- a/_posts/2019-05-01-#15557.md
+++ b/_posts/2019-05-01-#15557.md
@@ -10,6 +10,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:01 <@jnewbery> Hi folks!
 13:01 < harding> Hi!
 13:01 < dmkathayat> Hello!
@@ -237,3 +238,4 @@ status: past
 14:01 < RubenSomsen> Thanks John :)
 14:01 <@jnewbery> Feedback is most definitely welcome. Also let me know if you have suggestions for PRs to cover. The aim is for manageable sized PRs (ie 100-150 LOC change seems about right), not too much contextual knowledge required, and trying to cover all the different components
 14:02 <@jnewbery> Feel free to leave feedback in this IRC channel. I'll be monitoring through the week
+{% endirc %}

--- a/_posts/2019-05-08-#10823.md
+++ b/_posts/2019-05-08-#10823.md
@@ -10,6 +10,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 <@jnewbery> Hi all! Welcome to episode two of the Bitcoin Core PR Review club.
 13:00 <@jnewbery> This week, we're talking about PR10823 - "Allow all mempool txs to be replaced after a configurable timeout (default 6h) #10823".
 13:00 < merehap> Hi!
@@ -193,3 +194,4 @@ status: past
 14:01 < merehap> Thanks!
 14:01 < b10c> Thanks!
 14:01 <@jnewbery> info is here: https://gist.github.com/jnewbery/6e2797a6f484de59aefc849a6b184008 . The current plan is to review #14856 next week, but I might update that so keep an eye here and on the gist.
+{% endirc %}

--- a/_posts/2019-05-15-#15834.md
+++ b/_posts/2019-05-15-#15834.md
@@ -10,6 +10,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 12:59 < afig> sup yall
 13:00 < jb55> yo
 13:00 < jnewbery> hi
@@ -158,3 +159,4 @@ status: past
 13:59 < jnewbery> let's wrap it up there. As always, feel free to ping me if you have any thoughts about these.
 13:59 < pinheadmz> jnewbery: thank you! this is great, informative, fun
 13:59 < pinheadmz> to the moon!
+{% endirc %}

--- a/_posts/2019-05-22-#15450.md
+++ b/_posts/2019-05-22-#15450.md
@@ -21,6 +21,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:02 < jnewbery> hi!
 13:02 < dmkathayat_> Hi!
 13:02 < davterra> Hi!
@@ -129,3 +130,4 @@ status: past
 13:45 < michaelfolkson> Ok understood, thanks
 13:45 < michaelfolkson> Ok I'll let you go, many thanks
 13:46 < jnewbery> ok, thanks again. See you all next time!
+{% endirc %}

--- a/_posts/2019-05-29-#15741.md
+++ b/_posts/2019-05-29-#15741.md
@@ -10,6 +10,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 10:58 < jnewbery> Reminder that this week's meeting starts in two hours. We'll be looking at #15741
 10:58 < jnewbery> https://bitcoin-core-review-club.github.io/
 10:59 < jnewbery> ariard is going to host the meeting this week
@@ -222,3 +223,4 @@ status: past
 14:08 < jnewbery> ariard: the next assumeutxo PR is https://github.com/bitcoin/bitcoin/pull/15976 . It's a refactor but it touches consensus/validation code, so it needs careful review
 14:09 < jnewbery> There's another good resoure on profiling here: https://github.com/bitcoin/bitcoin/pull/12649/files#diff-d47c2f6882badae58f3881a6ce0a430cR89
 14:59 < jnewbery> I've put my git-pr and git-br tools up at https://gist.github.com/jnewbery/1d45a6b5e14b3f3fefe5942d0cc2608d. YMMV, no representations or warranties, expressed or implied, etc, etc
+{% endirc %}

--- a/_posts/2019-06-05-#16060.md
+++ b/_posts/2019-06-05-#16060.md
@@ -49,6 +49,7 @@ useful.
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi!
 13:00 < jonatack__> hi!
 13:00 < pinheadmz> Yo
@@ -211,3 +212,4 @@ useful.
 14:02 < jonatack__> The test is here: https://github.com/bitcoin/bitcoin/compare/master...sdaftuar:test-15834
 14:03 < michaelfolkson> Sure I would
 14:03 < peevsie> thanks all!
+{% endirc %}

--- a/_posts/2019-06-12-#15996.md
+++ b/_posts/2019-06-12-#15996.md
@@ -10,6 +10,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi!
 13:00 < moneyball> hi
 13:00  * zenogais waves
@@ -173,3 +174,4 @@ status: past
 14:01 < michaelfolkson> Thanks
 14:01 < setpill> thanks
 14:06 < moneyball> thanks jnewbery and all participants!
+{% endirc %}

--- a/_posts/2019-06-19-#15481.md
+++ b/_posts/2019-06-19-#15481.md
@@ -55,6 +55,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi
 13:00 < kanzure> hi
 13:00 < pinheadmz> hi
@@ -245,3 +246,4 @@ status: past
 13:54 < jnewbery> I'm out of office and won't make the next couple of review clubs. I'm going to try to find someone else to host, so keep an eye out on the website for details.
 13:56 < jnewbery> jonatack: I believe Matt has some updates to make to his consensus cleanup proposal. I'm going to hold off on concept reviewing until after that
 13:57 < jonatack> jnewbery: thanks
+{% endirc %}

--- a/_posts/2019-06-26-#15681.md
+++ b/_posts/2019-06-26-#15681.md
@@ -138,6 +138,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 12:59 < sosthene> Hi everyone
 13:00 < harding> Hi everyone.  John Newbery is off today, so I'll be hosting this week's meeting.  Let's get started by everyone saying hi and letting us know if you did any homework---read this week's PR, tried building it, read the notes at https://bitcoin-core-review-club.github.io/15681.html, read the mailing list discussion related to the PR, or did any other reviewing before the meeting (it's ok if
 13:00 < harding> you didn't).
@@ -224,6 +225,7 @@ status: past
 13:55 < harding> lightlike: yeah.  I was thinking, in this case, maybe what should've been done is look at the existing tests for CPFP and make sure they're extended to cover all of the new cases being added.
 13:57 < harding> E.g. the previous tests assumed that if you hit 101,000 vbytes, a failure was expected.  The new rule made those not always failures depending on the ancestry of the transaction being spent, so it'd be important to make sure that if the (1) old 101,000 vbyte condition was met, (2) the new carve-out condition was met, that (3) the old test failed any addition new transactions again.
 13:58 < harding> Anyway, that seems to be it for this topic.  Thank you all for coming!  Next week's topic is "#15443 Add getdescriptorinfo functional test (tests)", https://bitcoin-core-review-club.github.io/15443.html
+{% endirc %}
 
 [transaction pinning]: https://bitcoin.stackexchange.com/questions/80803/what-is-meant-by-transaction-pinning
 [pr #7600]: https://github.com/bitcoin/bitcoin/pull/7600

--- a/_posts/2019-07-03-#15443.md
+++ b/_posts/2019-07-03-#15443.md
@@ -51,6 +51,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi!
 13:00 < lightlike> hi!
 13:00 < ariard> hi!
@@ -199,3 +200,4 @@ status: past
 21:03 < wumpus> jnewbery: I think the reasoning is that RPC is a separate 'subsystem' from whatever is being tested (it needs to be specifically initialized/torn down), so anything testing RPC *and something else* is already a functional/integration test
 21:05 < wumpus> the internal functions used by RPC methods can of course, independently, be tested in unit tests, especially if they're pure utility functions
 21:05 < wumpus> but really calling RPC methods from unit tests is somewhat frowned upon, unless it's unit testing of the RPC system
+{% endirc %}

--- a/_posts/2019-07-10-#16244.md
+++ b/_posts/2019-07-10-#16244.md
@@ -23,6 +23,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi
 13:00 < fjahr> hi
 13:00 < behradkhodayar> Hi
@@ -191,3 +192,4 @@ status: past
 13:58 < MarcoFalke> https://github.com/bitcoin/bitcoin/pull/16244#issuecomment-509651561
 13:58 < jnewbery> haha. review club so good that PRs just merged
 13:59 < jnewbery> Yes, addressing that feedback could be a fun task for anyone here
+{% endirc %}

--- a/_posts/2019-07-17-#15169.md
+++ b/_posts/2019-07-17-#15169.md
@@ -37,6 +37,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 12:57 < digi_james>  Hello everyone :)
 12:58 < jonatack> Hi James :)
 12:59 < digi_james> jonatack: :)
@@ -222,3 +223,4 @@ status: past
 14:04 < jnewbery> Tough PR this week. Great job uncovering the subtleties.
 14:04 < hugohn> wouldn't one reason be that CheckInputs() is also called by BlockConnected(), which already does things in parallel?
 14:05 < jonatack> Thanks digi_james and everyone!
+{% endirc %}

--- a/_posts/2019-07-24-#15713.md
+++ b/_posts/2019-07-24-#15713.md
@@ -55,6 +55,7 @@ order from `cs_main` before `cs_wallet` to `cs_wallet` before `cs_main`.
 
 ## Meeting Log
 
+{% irc %}
 07:00 < jnewbery> hi
 07:00  * bpo wave
 07:00 < lightlike> hi
@@ -206,3 +207,4 @@ order from `cs_main` before `cs_wallet` to `cs_wallet` before `cs_main`.
 07:59 < jonatack> amiti: nice :+1:
 08:00 < jnewbery> ok, let's wrap it up there. Reminder that next week we'll look at https://github.com/bitcoin/bitcoin/pull/15505. It's been closed, but it's still an interesting PR, and if enough of us review it, maybe we can get it opened again and merged!
 08:01 < jnewbery> thanks everyone!
+{% endirc %}

--- a/_posts/2019-07-31-#15505.md
+++ b/_posts/2019-07-31-#15505.md
@@ -24,6 +24,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery_> hi
 13:00 < lightlike> hello
 13:00 < jkczyz> hi
@@ -171,3 +172,4 @@ status: past
 14:01 < jnewbery_> Before we go: next week PR review is looking at *two* competing PRs! https://bitcoin-core-review-club.github.io/16345.html
 14:01 < jnewbery_> notes are already up
 14:02 < jonatack> nice
+{% endirc %}

--- a/_posts/2019-08-07-#16345.md
+++ b/_posts/2019-08-07-#16345.md
@@ -31,6 +31,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi
 13:00 < kanzure> hi
 13:00 < emilengler> Hi
@@ -223,3 +224,4 @@ status: past
 13:54 < hanh> Thanks jnewbery
 13:55 < lightlike> thanks!
 13:56 < emilengler> Yes thank you all especially you jnewbery
+{% endirc %}

--- a/_posts/2019-08-14-#16115.md
+++ b/_posts/2019-08-14-#16115.md
@@ -28,6 +28,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi
 13:00 < nehan> hi
 13:00 < jkczyz> hi
@@ -194,3 +195,4 @@ status: past
 13:55 < jonatack> jnewbery, wumpus: thanks! ... thanks, everyone!
 13:55 < fanquake> That PSBT shuffle inputs PR will be a good one.
 13:55 < nehan> thanks!
+{% endirc %}

--- a/_posts/2019-08-21-#15931.md
+++ b/_posts/2019-08-21-#15931.md
@@ -60,6 +60,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi!
 13:00 < digi_james> Hello!
 13:00 < kanzure> hi
@@ -242,3 +243,4 @@ status: past
 14:07 < hugohn> AddToWalletIfInvolving bails if it's already seen the txn
 14:09 < hugohn> unless it's a forced update (fUpdate = true when rescanning)
 14:12 < hugohn> not sure of behavior when blocks are skipped
+{% endirc %}

--- a/_posts/2019-08-28-#15759.md
+++ b/_posts/2019-08-28-#15759.md
@@ -36,6 +36,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi
 13:00 < dergigi> hi
 13:00 < marcinja_> hi
@@ -239,3 +240,4 @@ status: past
 14:10 < ariard> ahah true
 14:11 < aj> jonatack: not really sure, twice as long as i plan to? :)
 14:12 < jonatack> aj: yeah, thanks, needed reassurance here :)
+{% endirc %}

--- a/_posts/2019-09-04-#16512.md
+++ b/_posts/2019-09-04-#16512.md
@@ -37,6 +37,7 @@ Please come prepared with your own questions about review in Bitcoin Core!
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi
 13:00 < jonatack> hi!
 13:00 < sosthene> hello there!
@@ -199,3 +200,4 @@ Please come prepared with your own questions about review in Bitcoin Core!
 14:03 < achow101> re bip69: according to p2sh.info, somewhere between 40% and 60% of txs use bip69. also core doesn't use bip69 at all
 14:08 < jonatack> achow101: thanks
 14:09 < milochen0418> thanks
+{% endirc %}

--- a/_posts/2019-09-11-#16688.md
+++ b/_posts/2019-09-11-#16688.md
@@ -33,6 +33,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jkczyz> hi
 13:00 < sosthene> nah it certainly comes from my side, happens all the time
 13:00 < lightlike> hi
@@ -145,3 +146,4 @@ status: past
 14:01 < jkczyz> So they can be covered in future weeks
 14:01 < jkczyz> lightlike: Thanks! This was fun :)
 14:02 < lightlike> jkczyz: gonna review/ack on github in the next days.
+{% endirc %}

--- a/_posts/2019-09-18-#15204.md
+++ b/_posts/2019-09-18-#15204.md
@@ -35,6 +35,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi!
 13:00 < jkczyz> hi
 13:01 < michaelfolkson> Hey
@@ -200,3 +201,4 @@ status: past
 14:01 < jonatack> (to start running the GUI wallet, sorry)
 14:02 < jonatack> sebastianvstaa: any problems, don't hesitate to PM us :)
 14:05 < sebastianvstaa> jonatack: sure, thanks!
+{% endirc %}

--- a/_posts/2019-09-25-#16202.md
+++ b/_posts/2019-09-25-#16202.md
@@ -58,6 +58,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 19:00 <jonatack> Hi all! Welcome to this week's episode of the Bitcoin Core PR Review club.
 19:00 <fjahr> hi
 19:00 <pinheadmz> hi
@@ -250,6 +251,7 @@ status: past
 20:00 <jonasschnelli> thanks all
 20:00 <zenogais> Thanks all, appreciate you fielding our questions jonasschnelli
 20:00 <sebastiavstaa> thanks all
+{% endirc %}
 
 ## Erratum
 

--- a/_posts/2019-10-02-#16401.md
+++ b/_posts/2019-10-02-#16401.md
@@ -80,6 +80,7 @@ relaying transactions after they expire from mapRelay."
 
 ## Meeting Log
 
+{% irc %}
 19:00 <jonatack> Hi all! Welcome to this week's episode of the Bitcoin Core PR Review club.
 19:00 <jonatack> We usually start Bitcoin Core IRC meetings with a 'hi' so it's clear who's at keyboard. Feel free to say hi!
 19:01 <jkczyz> hi
@@ -221,3 +222,4 @@ relaying transactions after they expire from mapRelay."
 20:02 <lightlike> thanks!
 20:04 <jonatack> zenogais: thanks for adding tests!
 20:05 <zenogais> Of course!
+{% endirc %}

--- a/_posts/2019-10-09-#16939.md
+++ b/_posts/2019-10-09-#16939.md
@@ -86,6 +86,7 @@ NACK?](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-revie
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi
 13:00 < sebastianvstaa> hi
 13:00 < amiti> hi
@@ -196,3 +197,4 @@ NACK?](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-revie
 13:58 < lightlike> thanks!
 13:59 < jnewbery> thanks all!
 13:59 < jonatack> thanks!
+{% endirc %}

--- a/_posts/2019-10-16-#16279.md
+++ b/_posts/2019-10-16-#16279.md
@@ -68,6 +68,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> hi
 13:00 < zenogais> hi
 13:00 < fox2p> hey
@@ -273,3 +274,4 @@ status: past
 14:11 < ariard> thanks
 14:11 < sebastianvstaa> thanks
 14:11 < ajonas> thanks John
+{% endirc %}

--- a/_posts/2019-10-23-#15934.md
+++ b/_posts/2019-10-23-#15934.md
@@ -67,6 +67,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < emilengler> Hello
 13:00 < jnewbery> hi
 13:00 < ajonas> Hi
@@ -217,3 +218,4 @@ status: past
 14:02 < jnewbery> ryanofsky: you missed it: https://bitcoincore.reviews/15931.html :)
 14:02 < ryanofsky> wow, ok!
 14:03 < ajonas> thanks jnewbery
+{% endirc %}

--- a/_posts/2019-10-30-#15921.md
+++ b/_posts/2019-10-30-#15921.md
@@ -69,6 +69,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 <@jnewbery> hi!
 13:00 < kanzure> hi
 13:00 < diogoser1io> hello!
@@ -214,3 +215,4 @@ status: past
 13:57 < fjahr> thanks john! and all :)
 13:57 < amiti> thanks !
 13:58 < diogosergio> Thanks, it was good to follow this up!
+{% endirc %}

--- a/_posts/2019-11-06-#15845.md
+++ b/_posts/2019-11-06-#15845.md
@@ -58,6 +58,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 12:00 <@jnewbery> #startmeeting
 12:00 <@jnewbery> hi!
 12:00 < jonatack> hi
@@ -323,3 +324,4 @@ status: past
 13:19 < MarcoFalke> +1
 13:19 < MarcoFalke> This one was eye-opening
 13:19 < sebastianvstaa> +1
+{% endirc %}

--- a/_posts/2019-11-13-#17303.md
+++ b/_posts/2019-11-13-#17303.md
@@ -52,6 +52,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 <@jnewbery> #startmeeting
 13:00 < MarcoFalke> ping
 13:00 < kanzure> hi
@@ -313,3 +314,4 @@ status: past
 14:06 <@jnewbery> I'll try to get notes and questions up for next week's meeting before the weekend. I'm travelling so I might not be able to attend but I think I have a host lined up
 14:07 < jonatack> jasonzhouu: MacroFalke, i like that +1
 14:07 < pinheadmz> !!!
+{% endirc %}

--- a/_posts/2019-11-20-#16442.md
+++ b/_posts/2019-11-20-#16442.md
@@ -45,6 +45,7 @@ Are there other ways to test this PR outside of the usual testing framework?
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> #startmeeting
 13:00 < jnewbery> hi
 13:00 < pinheadmz> hi
@@ -318,3 +319,4 @@ Are there other ways to test this PR outside of the usual testing framework?
 14:05  * pinheadmz headbanging \m/
 14:05 < andrewtoth> thanks!
 14:05 < emzy> tnx!
+{% endirc %}

--- a/_posts/2019-11-27-#16698.md
+++ b/_posts/2019-11-27-#16698.md
@@ -78,6 +78,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> #startmeeting
 13:00 < b10c> hi
 13:00 < jnewbery> hi everyone!
@@ -416,3 +417,4 @@ status: past
 14:53 < michaelfolkson> URL doesn't work for me
 14:53 < jonatack> it's in the repo with the other functional tests in: test/functional/wallet_listsinceblock.py
 14:55 < michaelfolkson> Ah ok thanks! See ya
+{% endirc %}

--- a/_posts/2019-12-04-#16426.md
+++ b/_posts/2019-12-04-#16426.md
@@ -76,6 +76,7 @@ status: past
 
 ## Meeting Log
 
+{% irc %}
 13:00 < ariard> #startmeeting
 13:00 < emilengler> hello
 13:00 < jnewbery> hi
@@ -245,3 +246,4 @@ status: past
 14:06 < ariard> fanquake: one issue per-idea or big issues and listing everything ?
 14:08 < fanquake> 1 issue per big idea/refactor is probably fine. If there's nits/small follows up, probably best to combine them all into a single issue.
 14:09 < fanquake> Main point is just not to lose PR commentary/things that should be done as follow ups post merge.
+{% endirc %}

--- a/_posts/2019-12-11-#16702.md
+++ b/_posts/2019-12-11-#16702.md
@@ -183,6 +183,7 @@ al. (February 2019)
 
 ## Meeting Log
 
+{% irc %}
 10:04 < jonatack> For testing today's review club PR 16702, the following real asmap file works:
 10:04 < jonatack>  https://github.com/sipa/asmap/demo.map
 10:06 < jonatack> launch bitcoind with : bitcoind -asmap=<path-to>/asmap/demo.map and the log should output "2019-12-11T15:01:16Z Opened asmap file (932999 bytes) from disk."
@@ -423,3 +424,4 @@ al. (February 2019)
 14:02 < jonatack> everyone: next week we will tentatively be looking at a PR to improve valgrind integration into Bitcoin Core, to help detect issues like the one that recently caused the 0.19.0.1 patch release.
 14:02 < gleb> survey: It's actually pretty generalizable I would say.
 14:02 < survey> yeah that's my thinking
+{% endirc %}

--- a/_posts/2019-12-18-#17639.md
+++ b/_posts/2019-12-18-#17639.md
@@ -182,6 +182,7 @@ tests with valgrind memcheck.
 
 ## Meeting Log
 
+{% irc %}
 18:33 <jonatack> Hi everyone, we'll get started a little under a half hour
 18:34 <jonatack> About the session notes today: if you have any corrections or improvements to suggest, please share!
 18:35 <jonatack> I'd like the notes, questions, and discussion to be a resource that people can use or come back to on this subject.
@@ -332,3 +333,4 @@ tests with valgrind memcheck.
 20:00 <emzy> Thanks and Happy holidays everyone!
 20:01 <amiti> thanks all ! thanks for the notes & hosting jonatack
 20:02 <jonatack> ty amiti :)
+{% endirc %}

--- a/_posts/2020-01-08-#14053.md
+++ b/_posts/2020-01-08-#14053.md
@@ -94,6 +94,7 @@ commit: ec5fbd0b
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> #startmeeting
 13:00 < jkczyz> hi
 13:00 < jonatack> hi
@@ -315,3 +316,4 @@ commit: ec5fbd0b
 14:01 < _andrewtoth_> EPS uses the wallet and imports the addresses, then does a rescan
 14:01 < jnewbery> Next week is fuzzing, hosted by MarcoFalke. Notes are already available: https://bitcoincore.reviews/17860.html
 14:01 < jnewbery> #endmeeting
+{% endirc %}

--- a/_posts/2020-01-15-#17860.md
+++ b/_posts/2020-01-15-#17860.md
@@ -68,6 +68,7 @@ commit: 8b868f17
 
 ## Meeting Log
 
+{% irc %}
 11:31 < instagibbs> I can't actually get the fuzztester to "Do anything". The readme focuses on setting up but doesn't actually give an example with expected output.
 11:31 < instagibbs> ./test/fuzz/test_runner.py ${DIR_FUZZ_IN}
 11:32 < instagibbs> results in it just printing out a bunch of names in arrays "Fuzz targets found" and "Fuzz targets selected" then exiting
@@ -437,3 +438,4 @@ commit: 8b868f17
 14:08 < jonatack> thanks MarcoFalk_, excellent meeting and study resources. Learning a lot.
 14:08 < dude> MarcoFalk_, do you run afl-tmin, afl-cmin on your corpus?
 14:08 < MarcoFalk_> If you find the docs hard, please also file an issue or improve them :)
+{% endirc %}

--- a/_posts/2020-01-22-#17477.md
+++ b/_posts/2020-01-22-#17477.md
@@ -172,6 +172,7 @@ commit: 100d5d03f
 
 ## Meeting Log
 
+{% irc %}
 17:03 <jonatack> We'll get started in a little under 2 hours for this week's Review Club episode
 18:09 <pinheadmz> Last week we were talking about code coverage -- I notice bitcoin isn't using Coveralls from Travis to report coverage on PRs - is there a reason why not?
 18:18 <jonatack> curious what difftools everyone is using for reviewing... i've been using gitk (with dracula for dark mode) but wish i could switch from red/green to nicer syntax highlighting sometimes
@@ -400,3 +401,4 @@ commit: 100d5d03f
 20:14 <jonatack> fjahr: amiti: agree, i think going through the existing tests on this topic and noodling with adding any that seem missing could be time well-spent
 20:14 <jonatack> to think through the cases
 20:20 <michaelfolkson> amiti: It's ok. I don't think I understood your question :)
+{% endirc %}

--- a/_posts/2020-01-29-#17487.md
+++ b/_posts/2020-01-29-#17487.md
@@ -110,6 +110,7 @@ cache after writing them to disk.
 
 ## Meeting Log
 
+{% irc %}
 18:58 <jamesob> Okay folks, in a few minutes we're going to get started on the meeting for https://bitcoincore.reviews/17487.html
 19:00 <jamesob> #startmeeting
 19:00 <fjahr> hi
@@ -357,3 +358,4 @@ cache after writing them to disk.
 20:07 <jnewbery> here's a write-up of the UTXO changes in v0.15: https://johnnewbery.com/post/whats-new-in-bitcoin-core-v0.15-pt1/
 20:07 <jnewbery> (I didn't want to derail the conversation during the meeting)
 20:08 <michaelfolkson> Thanks
+{% endirc %}

--- a/_posts/2020-02-05-#18044.md
+++ b/_posts/2020-02-05-#18044.md
@@ -91,6 +91,7 @@ commit: c4a23a1
 
 ## Meeting Log
 
+{% irc %}
 18:03 <jonatack> We'll get started in an hour -- hopefully everyone isn't at Advancing Bitcoin today :)
 18:03 <jonatack> Some thoughts I wanted to share before the meeting:
 18:03 <jonatack> A few people have been contacting me privately with questions about the PR or how to review.
@@ -415,3 +416,4 @@ commit: c4a23a1
 21:37 <sdaftuar> and it should be easy to remove either before or after the wtxid-relay PR
 21:38 <sdaftuar> (if we can get rid of mapRelay before, i can easily pull that commit out of my branch)
 21:39 <aj> sdaftuar: oh, yeah, not a meaningful criticism
+{% endirc %}

--- a/_posts/2020-02-12-#16902.md
+++ b/_posts/2020-02-12-#16902.md
@@ -115,6 +115,7 @@ NACK?](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-revie
 
 ## Meeting Log
 
+{% irc %}
 13:00 < fode> hi
 13:00 < jnewbery> #startmeeting
 13:00 < ajonas> Hi
@@ -294,3 +295,4 @@ NACK?](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-revie
 14:03 < nehan_> fjahr: i think you're right
 14:04 < jonatack> Lost the connection again. Curious to catch up with the discussion. It seems to me though that these changes are strictly better.
 14:05 < jonatack> Great question though!
+{% endirc %}

--- a/_posts/2020-02-19-#17954.md
+++ b/_posts/2020-02-19-#17954.md
@@ -93,6 +93,7 @@ to drop?
 
 ## Meeting Log
 
+{% irc %}
 12:59 < luke-jr> hi
 13:00 < emilengler> hi
 13:00 < SirRichard> hi
@@ -216,3 +217,4 @@ to drop?
 14:06 < ryanofsky> Ah well, soon enough github will have an integrated IRC and we will avoid these problem
 14:06 < jonatack> more reliance on github? goodness, i certainly hope not
 14:07 < frenchNoob> Thanks
+{% endirc %}

--- a/_posts/2020-02-26-#17428.md
+++ b/_posts/2020-02-26-#17428.md
@@ -150,6 +150,7 @@ NACK?](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-revie
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> #startmeeting
 13:00 < amiti> jnewbery you beat me to it!
 13:00 < rockzombie2> hi
@@ -457,3 +458,4 @@ NACK?](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-revie
 14:04 < instagibbs> worst-case for now it's 2 additional anchor connections which I don't think in practice will matte
 14:04 < instagibbs> obviously more blocks only connections would change this
 14:11 < nothingmuch> fwiw it appears addnode is capped at 8 independently of other outbound conns
+{% endirc %}

--- a/_posts/2020-03-04-#16981.md
+++ b/_posts/2020-03-04-#16981.md
@@ -84,6 +84,7 @@ NACK?](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-revie
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> #startmeeting
 13:00 < jnewbery> Hi folks! Welcome to Bitcoin Core PR Review Club. Feel free to say hi to let everyone know you're at keyboard.
 13:00 < emilengler> hi
@@ -404,3 +405,4 @@ NACK?](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#peer-revie
 06:10 <RubenSomsen> Thanks kalle :)
 06:10 <kallewoof> coinsureNZ: Thanks for joining!
 06:11 <kallewoof> #endmeeting
+{% endirc %}

--- a/_posts/2020-03-11-#17824.md
+++ b/_posts/2020-03-11-#17824.md
@@ -77,6 +77,7 @@ of coin selection? Can you think of different solutions to the problem?
 
 ## Meeting Log
 
+{% irc %}
 13:17 < jonatack> git grepping shows EXTRA_DESCENDANT_TX_SIZE_LIMIT = 10000, related?
 13:26 < fjahr> yeah, that's also my understanding but I took it from kalle's suggestion here https://github.com/bitcoin/bitcoin/pull/17824#issuecomment-570548151 and did not explicitly clarify if he chose it for another reason.
 13:27 < jonatack> right, thanks, it's the only place i saw it too... I think the value should be commented and maybe hoisted to a static constant
@@ -473,3 +474,4 @@ of coin selection? Can you think of different solutions to the problem?
 05:57 <kallewoof> thanks! :D
 05:58 <Murch> alright, good night
 05:58 <kallewoof> night Murch!
+{% endirc %}

--- a/_posts/2020-03-18-#18113.md
+++ b/_posts/2020-03-18-#18113.md
@@ -79,6 +79,7 @@ A summary of the validity of possible states, with explanation:
 
 ## Meeting Log
 
+{% irc %}
 13:00 < jnewbery> #startmeeting
 13:00 < jkczyz> hi
 13:00 < willcl_ark> hi
@@ -299,3 +300,4 @@ A summary of the validity of possible states, with explanation:
 14:03 < fjahr> ok
 14:03 < jonatack> fjahr: I'm thinking it's possible but only benchmarking can tell. Have to measure.
 14:03 < jnewbery> jonatack: agree with benchmarking
+{% endirc %}


### PR DESCRIPTION
Now that build speed appears to no longer be an issue thanks to #154, this PR updates @harding's callable filter suggestion implemented by @jnewbery in https://github.com/bitcoin-core-review-club/bitcoin-core-review-club.github.io/tree/pr147.2

Co-authored-by: John Newbery john@johnnewbery.com
Co-authored-by: David A. Harding <dave@dtrt.org>
