### PR TITLE
Add test and fix for empty nicks in site content

### DIFF
--- a/_plugins/auto_logs_markup.rb
+++ b/_plugins/auto_logs_markup.rb
@@ -59,6 +59,7 @@ module Jekyll
         nick    = name.gsub(LT_GT, '').strip
         color   = colors[nick] || (color_index = (color_index + 1) % NUM_COLORS ;
                                    colors[nick] = COLORS[color_index])
+        nick    = "&lt;#{nick}&gt;" unless nick == ''
         message = CGI.escapeHTML(line[TIME_SIZE_PLUS_1 + name.size..-1])
 
         # Extract URIs from the message and convert them to HTML links.
@@ -73,7 +74,7 @@ module Jekyll
             "<td class='log-lineno'><a href='#l-#{index}'>#{lineno}</a></td>" \
             "<td class='log-time'>#{time}</td>" \
             "<td>" \
-              "<span class='log-nick' style='color:#{color}'>&lt;#{nick}&gt;</span>" \
+              "<span class='log-nick' style='color:#{color}'>#{nick}</span>" \
               "<span class='log-msg'>#{message}</span>" \
             "</td>" \
           "</tr>" \

--- a/test/test_site_content.rb
+++ b/test/test_site_content.rb
@@ -25,6 +25,14 @@ class TestSiteContent < Minitest::Test
     @body = http.body
   end
 
+  def test_site_displays_no_empty_nicks
+    # Check that no empty nicks are displayed, e.g. "<> * luke-jr wonders..."
+    # To run only this test:
+    # rake TEST=test/test_site_content TESTOPTS=--name=test_site_displays_no_empty_nicks
+    #
+    refute @body.include? "&amp;lt;&amp;gt;"
+  end
+
   def test_all_links
     # Check the HTTP status of all URLs in the site-wide XML feed.
     # To run only this test:


### PR DESCRIPTION
Add a one-line test and a two-line fix for empty nicks like https://bitcoincore.reviews/17428.html#l-242
```
242 13:52 <> * luke-jr , before running out of time, wonders...
```
To run the test:
```
$ make preview
$ rake TEST=test/test_site_content TESTOPTS=--name=test_site_displays_no_empty_nicks
```
or swap lines 14 and 15 in `test_site_content.rb` to run the test on the production website:
```
$ rake TEST=test/test_site_content TESTOPTS=--name=test_site_displays_no_empty_nicks
```
The test currently fails in production and passes locally in the PR branch.

This PR is based on #45.
