### PR TITLE
n18113: fix link that changed from 200 to 404

### DIFF
--- a/_posts/2020-03-18-#18113.md
+++ b/_posts/2020-03-18-#18113.md
@@ -264,7 +264,7 @@ A summary of the validity of possible states, with explanation:
 13:56 < jnewbery> amiti: sorry you're right. Replace my first one with (spent and not-FRESH and DIRTY)
 13:56 < nehan_> why wouldn't the first one happen?
 13:57 < nehan_> that seems like the case where you read a spent UTXO from the parent
-13:57 < jnewbery> nehan_: after this PR, we wouldn't keep it: https://github.com/bitcoin/bitcoin/pull/18113/commits/7053da36bf3879f1f160303f369605fd91ba957d#diff-cd7b305fd4b4280f22ae88960e60398eR48
+13:57 < jnewbery> nehan_: after this PR, we wouldn't keep it: https://github.com/bitcoin-core-review-club/bitcoin/commit/7053da3#diff-cd7b305fd4b4280f22ae88960e60398eR48
 13:57 < willcl_ark> jonatack: agree, FRESH is too close to (the opposite of DIRTY,) CLEAN
 13:57 < nehan_> jnewbery: ah right, thanks
 13:58 < willcl_ark> ...although CCoinsCacheEntry::Flags does explain pretty clearly what the two flags mean


### PR DESCRIPTION
While running the tests to check #166, they found a link that just went from 200 to 404 due to a force push in the PR. This kind of fix could arguably be automated at some point.